### PR TITLE
Phase 0: repo cleanup (.gitignore, README fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,17 @@
 # Python compile and backup files
 *.pyc
 *.py.bak
+__pycache__/
 
 # Build and deploy
 build/
 dist/
-do_py.egg-info
+*.egg-info/
 node_modules/
+
+# Virtual envs
+.venv/
+venv/
 
 # Testing
 .coverage
@@ -16,7 +21,13 @@ htmlcov/
 test-reports/
 py2to3cov/
 
+# Lint / tool caches
+.ruff_cache/
+.mypy_cache/
+.tox/
+
 # Misc
 .idea/
+.vscode/
 .DS_Store
 .python-version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Do-Py, shorthand for DataObject Python, is a data-validation and standardization library wrapping Python dictionaries.
 
 ![release](https://img.shields.io/github/package-json/v/do-py-together/do-py?label=release&logo=release&style=flat-square)
-![build](https://img.shields.io/github/workflow/status/do-py-together/do-py/test?style=flat-square)
+![build](https://img.shields.io/github/actions/workflow/status/do-py-together/do-py/python-app.yml?branch=master&style=flat-square)
 ![coverage](https://img.shields.io/codecov/c/github/do-py-together/do-py?style=flat-square)
 ![dependencies](https://img.shields.io/librariesio/release/pypi/do-py?style=flat-square)
 

--- a/README.md
+++ b/README.md
@@ -160,17 +160,21 @@ from do_py import DataObject, R
 
 
 class Contact(DataObject):
+    """
+    Contact information for an author.
+    :restriction phone_number: A phone number as a string.
+    """
     _restrictions = {
-        'phone_number'
+        'phone_number': R.STR
         }
 
 
 class Author(DataObject):
     """
-    A DataObject that contains all of my favorite items.
-    :restriction id:
-    :restriction favorite_candy: My favorite candy, this is restricted by value.
-    :restriction favorite_movie: My favorite movie. This is optional because a `None` IS allowed!
+    An author of a video game.
+    :restriction id: The author's id.
+    :restriction name: The author's name.
+    :restriction contact: Nested Contact DataObject.
     """
     _restrictions = {
         'id': R.INT,
@@ -181,10 +185,10 @@ class Author(DataObject):
 
 class VideoGame(DataObject):
     """
-    A DataObject that contains all of my favorite items.
-    :restriction id:
-    :restriction favorite_candy: My favorite candy, this is restricted by value.
-    :restriction favorite_movie: My favorite movie. This is optional because a `None` IS allowed!
+    A video game, authored by someone.
+    :restriction id: The video game's id.
+    :restriction name: The video game's name (optional).
+    :restriction author: Nested Author DataObject.
     """
     _restrictions = {
         'id': R.INT,
@@ -193,12 +197,18 @@ class VideoGame(DataObject):
         }
 
 
-# Data objects must be instantiated at their **init** with a dictionary and
-#   strict(True(default) or False)
+# DataObjects must be instantiated with a dictionary and strict=True (default) or False.
+# Nested DataObjects are built recursively from nested dicts.
 instance = VideoGame({
-    'favorite_number': 1985,
-    'favorite_candy': 'Jolly Ranchers',
-    'favorite_movie': 'Jolly Green Giant'
+    'id': 1985,
+    'name': 'Super Mario Bros.',
+    'author': {
+        'id': 1,
+        'name': 'Shigeru Miyamoto',
+        'contact': {
+            'phone_number': '555-0100'
+            }
+        }
     })
 
 print(instance)


### PR DESCRIPTION
## Phase 0 of the repo refresh

First cleanup pass — safe, no-functional-code changes. Prepares the repo for subsequent modernization phases (drop Python 2, migrate to `mise` + `uv`, etc.).

### Changes

**`.gitignore`**
- Add `__pycache__/`, broaden `do_py.egg-info` → `*.egg-info/`
- Add `.venv/`, `venv/` (for upcoming `uv` adoption)
- Add `.ruff_cache/`, `.mypy_cache/`, `.tox/`, `.vscode/`

**Remove tracked artifact**
- Delete zero-byte `test.json` (leftover, no purpose)

**README fixes**
- Fix broken nested-DataObject example:
  - `Contact._restrictions` was a set literal — now a proper dict with `R.STR`
  - `VideoGame({...})` was instantiated with `favorite_*` keys that don't exist on the class — rewritten to a valid nested `id` / `name` / `author` → `contact` structure
  - Rewrote copy-pasted docstrings on `Author` and `VideoGame`
- Update deprecated shields.io build-status badge URL (`/github/workflow/status/...` → `/github/actions/workflow/status/.../python-app.yml`)

### Not included (intentionally deferred)
- CI action version bumps → **Phase 1**
- Dropping Python 2 / removing `future` → **Phase 2**
- Packaging migration to `pyproject.toml` + `mise` + `uv` → **Phase 4**
- `release` badge still points at `package.json`; will be fixed when `package.json` is removed in Phase 4

### Verification
No code changed; existing tests/CI behavior unaffected. README example is now syntactically and semantically valid Do-Py code.