### PR TITLE
Phase 1: CI baseline - modernize Actions, drop Python 2.7 from matrix

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,12 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9]
+        python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
@@ -32,4 +33,4 @@ jobs:
           pipenv run pytest -so xfail_strict=True --durations 10 --maxfail 10 --cov ./ --cov-report html --cov-report xml --junitxml test-reports/tests.xml --cov-config=./tests/.coveragerc ./tests/
       # Set up posting code coverage to CodeCov.
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Phase 1 of the repo refresh

Minimal CI fix to restore a green baseline before tackling code modernization.

### Before this PR
CI was red on `master`: `setup-python` no longer provides Python 2.7 binaries, and with fail-fast (default true), that cancels the entire matrix. Additionally all three actions were pinned to versions flagged as Node.js 20 deprecated.

### Changes (`.github/workflows/python-app.yml`)
| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v2` | `@v4` |
| `actions/setup-python` | `@v2` | `@v5` |
| `codecov/codecov-action` | `@v1` | `@v4` |
| Python matrix | `[2.7, 3.7, 3.8, 3.9]` | `["3.9"]` |
| `fail-fast` | (default true) | `false` |

Matrix values are now quoted strings so YAML doesn't silently coerce `3.10` into `3.1` when we expand in Phase 3.

### Why the matrix collapsed to just 3.9
Walked through each existing entry:
- **2.7** — not provided by `setup-python` at all anymore
- **3.7** — not available on Ubuntu 24.04 (current `ubuntu-latest`)
- **3.8** — installs fine, but fails during test collection: modern `setuptools` now vendors a `typeguard` whose pytest plugin calls `add_ini_option("string")`, which the pinned `pytest 4.6.11` doesn't understand (`assert type in (None, 'pathlist', 'args', 'linelist', 'bool')`). Proper fix is upgrading pytest → Phase 5.
- **3.9** — resolves a compatible dep set and passes ✅

### Intentionally not done
- **No code changes.** `future`, `past.builtins`, `from builtins import object`, etc. will be removed in **Phase 2**.
- **No matrix expansion to 3.10-3.13.** That lands in **Phase 3** after Phase 2 removes Py2-compat code.
- **`pipenv` / `Pipfile` untouched.** Migration to `uv` / `mise` happens in **Phase 4**.
- **Dev deps untouched.** Upgrading `pytest` etc. is **Phase 5**.

### Verification
✅ CI green on Python 3.9 after this PR.

### Risk
Workflow-only change. No runtime code touched.