### PR TITLE
Phase 2: drop Python 2 support and remove `future` dependency

### DIFF
--- a/do_py/abc/__init__.py
+++ b/do_py/abc/__init__.py
@@ -3,8 +3,6 @@ Custom Abstract Base Classes to implement Restrictions. Developed for DataObject
 :date_created: 2018-12-05
 """
 
-from builtins import object
-
 from .constants import ConstABCR
 from .messages import SystemMessages
 from .utils import already_declared, compare_cls

--- a/do_py/abc/constants.py
+++ b/do_py/abc/constants.py
@@ -3,9 +3,6 @@ Constants to support base_model modules.
 :date_created: 2018-12-05
 """
 
-from builtins import object
-
-
 class ConstABCR(object):
     """
     Constants supporting ABCRestrictions

--- a/do_py/abc/messages.py
+++ b/do_py/abc/messages.py
@@ -4,9 +4,6 @@ System messages to directly support error messages in base_model modules.
 :author: Tim Davis
 """
 
-from builtins import object
-
-
 class SystemMessages(object):
     REQUIRED_FOR = '%s is required for %s!'
     GENERIC = 'Unknown error.'

--- a/do_py/common/__init__.py
+++ b/do_py/common/__init__.py
@@ -2,17 +2,10 @@
 Commonly used restrictions.
 :date_created: 2020-06-28
 """
-import sys
-
 from datetime import date, datetime
-from future.types import newint, newlist, newstr
-from past.builtins import long, unicode
 
 from do_py.data_object import Restriction
 from do_py.utils import classproperty
-
-
-IS_PY3 = sys.version_info.major == 3
 
 
 class R(object):
@@ -70,10 +63,7 @@ class R(object):
         Shortcut for an int restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(int, newint.newint)
-        else:
-            return cls(int, newint)
+        return cls(int)
 
     @classproperty
     def FLOAT(cls):
@@ -89,10 +79,7 @@ class R(object):
         Shortcut for string restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(str, newstr.newstr)
-        else:
-            return cls(str, unicode, newstr)
+        return cls(str)
 
     @classproperty
     def NULL_INT(cls):
@@ -100,10 +87,7 @@ class R(object):
         Shortcut for a nullable int restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(int, newint.newint, type(None))
-        else:
-            return cls(int, newint, type(None))
+        return cls(int, type(None))
 
     @classproperty
     def NULL_FLOAT(cls):
@@ -119,10 +103,7 @@ class R(object):
         Shortcut for a nullable string restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(str, newstr.newstr, type(None))
-        else:
-            return cls(str, unicode, newstr, type(None))
+        return cls(str, type(None))
 
     @classproperty
     def LIST(cls):
@@ -130,10 +111,7 @@ class R(object):
         Shortcut for a list restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(list, newlist.newlist)
-        else:
-            return cls(list, newlist)
+        return cls(list)
 
     @classproperty
     def SET(cls):
@@ -149,10 +127,7 @@ class R(object):
         Shortcut for a nullable list restriction.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(list, newlist.newlist, type(None))
-        else:
-            return cls(list, newlist, type(None))
+        return cls(list, type(None))
 
     @classproperty
     def BOOL(cls):
@@ -207,20 +182,22 @@ class R(object):
     def LONG_INT(cls):
         """
         Shortcut for a long int restriction.
+
+        NOTE: In Python 3, `long` has been unified with `int`, so this is
+        functionally identical to ``R.INT``. Kept for backward-compatible
+        restriction declarations.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(int, newint.newint, long)
-        else:
-            return cls(int, newint, long)
+        return cls(int)
 
     @classproperty
     def NULL_LONG_INT(cls):
         """
         Shortcut for a nullable long int restriction.
+
+        NOTE: In Python 3, `long` has been unified with `int`, so this is
+        functionally identical to ``R.NULL_INT``. Kept for backward-compatible
+        restriction declarations.
         :rtype: Restriction
         """
-        if IS_PY3:
-            return cls(int, newint.newint, long, type(None))
-        else:
-            return cls(int, newint, long, type(None))
+        return cls(int, type(None))

--- a/do_py/data_object/__init__.py
+++ b/do_py/data_object/__init__.py
@@ -28,9 +28,9 @@ class DataObject(RestrictedDictMixin):
         Matching _restrictions value:
         _restrictions = {
             'id': ([int], None),
-            'value': ([str, unicode], None),
-            'created': ([int, long], None),
-            'modified': ([int, long], None)
+            'value': ([str], None),
+            'created': ([int], None),
+            'modified': ([int], None)
             }
 
 

--- a/do_py/data_object/restriction.py
+++ b/do_py/data_object/restriction.py
@@ -4,15 +4,8 @@ Data Object Restrictions.
 """
 
 import copy
-import sys
 from abc import ABCMeta, abstractmethod, abstractproperty
-
-from builtins import object
 from datetime import date, datetime
-from future.moves import builtins
-from future.types import newint, newlist, newstr
-from future.utils import with_metaclass
-from past.builtins import long, unicode
 
 from ..abc import ABCRestrictionMeta
 from ..exceptions import RestrictionError
@@ -227,10 +220,7 @@ class _ListTypeRestriction(SingletonRestriction):
         """
         :rtype: str
         """
-        return ' or '.join({
-            x.__name__ for x in self.allowed
-            if x.__name__ not in ['newstr', 'newint', 'long']  # Exclude Py2/3 compatibility
-        })
+        return ' or '.join({x.__name__ for x in self.allowed})
 
     @property
     def es_restrictions(self):
@@ -521,7 +511,7 @@ class Restriction(object):
             raise RestrictionError.from_invalid_default_value(default)
         if isinstance(allowed, ManagedRestrictions):
             return _MgdRestRestriction(allowed, default=allowed.default, **kwargs)
-        elif type(allowed) in [list, newlist]:
+        elif type(allowed) is list:
             if len(allowed) == 0:
                 return _ListNoRestriction(allowed, default=default, **kwargs)
             elif len(allowed) == 2 and ABCRestrictionMeta in [type(e) for e in allowed]:
@@ -594,7 +584,7 @@ class Restriction(object):
             return cls(declaration)
 
 
-class ManagedRestrictions(object, with_metaclass(ABCMeta)):
+class ManagedRestrictions(object, metaclass=ABCMeta):
     """
     Useful for managing complex data validations for restrictions in DataObject. E.g.
     1. Regular expression validation such as review URL matches expected template.
@@ -733,27 +723,16 @@ class ESEncoder(object):
         """
         :rtype: dict
         """
-        encoding = {
+        return {
             int: ESR.INT,
-            long: ESR.INT,
-            builtins.int: ESR.INT,
             float: ESR.FLOAT,
-            builtins.float: ESR.FLOAT,
             datetime: ESR.DATE,
             date: ESR.DATE,
             bool: ESR.BOOL,
             str: ESR.STR,
-            builtins.str: ESR.STR,
-            unicode: ESR.STR,
             'keyword': ESR.KEYWORD,
             # list: {},
             }
-        if sys.version_info.major == 3:
-            encoding.update({
-                newint.newint: ESR.INT,
-                newstr.newstr: ESR.STR
-                })
-        return encoding
 
     @classmethod
     def default(cls, obj):

--- a/do_py/utils/properties.py
+++ b/do_py/utils/properties.py
@@ -5,8 +5,6 @@ Property decorators useful for organizing code in a DO.
 
 import inspect
 
-from builtins import object
-
 
 class classproperty(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/do-py-together/do-py',
-    install_requires=[
-        'future>=0.18'
-        ],
+    install_requires=[],
     packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
     # https://pypi.org/classifiers/
     classifiers=[
@@ -48,10 +46,7 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
         ],
     keywords=['development', 'OO']

--- a/tests/test_abc_restrictions.py
+++ b/tests/test_abc_restrictions.py
@@ -2,7 +2,6 @@
 :date_created: 2019-08-20
 """
 
-from builtins import object, str
 
 import pytest
 

--- a/tests/test_common/test_esr.py
+++ b/tests/test_common/test_esr.py
@@ -2,7 +2,6 @@
 :date_created: 2020-06-28
 """
 
-from builtins import object
 
 import pytest
 

--- a/tests/test_common/test_managed_datetime.py
+++ b/tests/test_common/test_managed_datetime.py
@@ -4,7 +4,6 @@
 from datetime import date, datetime
 
 import pytest
-from builtins import object
 
 from do_py import R
 from do_py.common.managed_datetime import MgdDatetime

--- a/tests/test_common/test_managed_list.py
+++ b/tests/test_common/test_managed_list.py
@@ -2,7 +2,6 @@
 :date_created: 2020-06-28
 """
 
-from builtins import object
 
 import pytest
 

--- a/tests/test_common/test_r.py
+++ b/tests/test_common/test_r.py
@@ -2,7 +2,6 @@
 :date_created: 2020-06-28
 """
 
-from builtins import object
 
 import pytest
 

--- a/tests/test_data_object/test_data_object.py
+++ b/tests/test_data_object/test_data_object.py
@@ -4,7 +4,6 @@ Test resource base model.
 """
 
 import json
-from builtins import object
 
 import pytest
 

--- a/tests/test_data_object/test_deepcopy.py
+++ b/tests/test_data_object/test_deepcopy.py
@@ -3,7 +3,6 @@
 """
 from copy import deepcopy
 
-from builtins import object
 
 from do_py import R
 from do_py.data_object import DataObject, Restriction

--- a/tests/test_data_object/test_dynamic_restrictions.py
+++ b/tests/test_data_object/test_dynamic_restrictions.py
@@ -3,7 +3,6 @@ Test dynamic restriction class creation, inheritance and usage.
 :date_created: 2020-07-10
 """
 import pytest
-from builtins import object
 
 from do_py import DataObject, R
 from do_py.data_object.dynamic_restrictions import dynamic_restriction_mixin

--- a/tests/test_managed_restrictions.py
+++ b/tests/test_managed_restrictions.py
@@ -4,7 +4,6 @@ Test managed restrictions.
 """
 import itertools as it
 import pytest
-from builtins import map, object, zip
 
 from do_py.common import R
 from do_py.data_object.restriction import ManagedRestrictions

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -4,12 +4,10 @@ Tests for restrictions.
 :author: AJ
 """
 
-from builtins import object
 from copy import deepcopy
-from future.types import newstr
-import pytest
 from datetime import date, datetime
-from future.utils import PY3
+
+import pytest
 
 from do_py import DataObject
 from do_py.common import R
@@ -118,7 +116,7 @@ class TestRestriction(object):
     @pytest.mark.parametrize('data', [
         None,
         'a',
-        newstr.newstr('b') if PY3 else newstr('b'),
+        str('b'),
         pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
         ])
     def test_null_str_values(self, data):
@@ -126,7 +124,7 @@ class TestRestriction(object):
 
     @pytest.mark.parametrize('data', [
         'a',
-        newstr.newstr('b') if PY3 else newstr('b'),
+        str('b'),
         pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError)),
         pytest.param(None, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
         ])

--- a/tests/test_utils/test_encoder.py
+++ b/tests/test_utils/test_encoder.py
@@ -1,5 +1,4 @@
 import json
-from builtins import object
 
 from datetime import datetime
 

--- a/tests/test_utils/test_properties.py
+++ b/tests/test_utils/test_properties.py
@@ -3,7 +3,6 @@ Test the property decorators and related utils.
 """
 import time
 
-from builtins import object
 
 from do_py.utils.properties import cached_classproperty, cached_property, classproperty, is_cached_property, \
     is_classmethod, is_property


### PR DESCRIPTION
## Phase 2 of the repo refresh — the keystone change

Removes all Python 2 compatibility code from `do_py/` and `tests/`, drops the `future` runtime dependency, and prunes Py2 trove classifiers. `do-py` is now a **zero-dependency** library.

Unlocks downstream phases: packaging migration (Phase 4), dev-dep refresh (Phase 5), and type annotations (Phase 6) all require Py3-only code.

### Commits
| SHA | Summary |
|---|---|
| `9bbec1f` | `refactor: remove Python 2 compatibility shims from do_py/` |
| `8d07644` | `test: remove Python 2 compatibility shims from tests/` |
| `b4e52f3` | ``build: drop `future` runtime dependency and Py2 trove classifiers`` |

### What was removed
- `from builtins import object` (and `map, zip, str`) — 15 occurrences across `do_py/` and `tests/`
- `from future.types import newint, newlist, newstr` and all `.newint` / `.newstr` / `.newlist` call sites
- `from past.builtins import long, unicode`, plus `long`/`unicode` references
- `from future.moves import builtins` and redundant `builtins.int`/`builtins.float`/`builtins.str` keys in `ESEncoder.encoding`
- `from future.utils import with_metaclass` → replaced with native `metaclass=ABCMeta` syntax on `ManagedRestrictions`
- `from future.utils import PY3` in `tests/test_restrictions.py` and its branched `newstr.newstr('b') if PY3 else newstr('b')` parametrize values → plain `str('b')`
- `IS_PY3 = sys.version_info.major == 3` sentinel and all its branches in `do_py/common/__init__.py` (kept only the Py3 path)
- `future>=0.18` from `setup.py` `install_requires`
- `Programming Language :: Python :: 2`, `:: 2.7`, `:: 3.7`, `:: 3.8` trove classifiers

### Behavioral changes worth calling out
1. **`R.LONG_INT` / `R.NULL_LONG_INT` preserved** as aliases for `R.INT` / `R.NULL_INT`. Under Py3, `long` was unified with `int`, so they're functionally identical now. Kept (with updated docstrings) so downstream `_restrictions` declarations don't break.
2. **`_ListTypeRestriction.schema_value`** no longer filters out `['newstr', 'newint', 'long']` from the emitted type names. That special case is obsolete — those types can't appear anymore. Net effect on schema output: identical for all real-world restrictions.
3. **`ESEncoder.encoding`** lost 5 redundant entries (`builtins.int`, `builtins.float`, `builtins.str`, `newint.newint`, `newstr.newstr`) that were all duplicates of the bare `int`/`float`/`str`/`int`/`str` keys under Py3. No runtime behavior change.
4. **Stale docstring example** in `do_py/data_object/__init__.py` that referenced `[str, unicode]` and `[int, long]` cleaned up to `[str]` and `[int]`.

### What was NOT changed (intentionally deferred)
- `super(X, self).__init__(...)` → `super().__init__(...)` — cosmetic, Phase 6
- `class X(object):` → `class X:` — cosmetic, Phase 6
- Matrix expansion to 3.10-3.13 — **Phase 3**
- `setup.py` → `pyproject.toml` + `Pipfile`/`package.json` removal — **Phase 4**
- `pytest` / `coverage` / `twine` dev dep upgrades — **Phase 5**

### Verification
Full test suite run locally on Python 3.12:
```
172 passed, 76 xfailed in 0.62s
```
(76 xfails match the master baseline — these are intentional `pytest.mark.xfail` markers for known-bad-input parametrize cases, not regressions.)

### Pipfile / Pipfile.lock
`Pipfile` does not reference `future` directly — it was pulled transitively via the editable `do-py` install. CI regenerates `Pipfile.lock` on every run (`rm Pipfile.lock && pipenv install --dev`), so no manual lockfile update needed.

### Risk
Moderate. Runtime behavior preserved end-to-end by the test suite, but anyone importing Py2-compat symbols from `do_py` internals (e.g. `do_py.common.IS_PY3`, or `newint`/`newstr` via `do_py.data_object.restriction`) will break. Those aren't public API, but still worth noting in release notes.