### PR TITLE
Phase 3: expand Python version support to 3.10-3.13

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/Pipfile
+++ b/Pipfile
@@ -12,10 +12,10 @@ test = "pytest -svo xfail_strict=True --durations 10 --maxfail 10 --cov ./ --cov
 do-py = { editable = true, path = "." }
 
 [dev-packages]
-pytest = "==4.6.11"
-pytest-cov = "==2.10.1"
-pytest-forked = "==1.3.0"
-pytest-timeout = "==1.4.2"
-pytest-xdist = "==1.34.0"
-coverage = "==4.5.1"
+pytest = ">=8"
+pytest-cov = ">=5"
+pytest-forked = ">=1.6"
+pytest-timeout = ">=2"
+pytest-xdist = ">=3"
+coverage = ">=7"
 twine = "==1.15"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,11 @@ setuptools.setup(
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         ],
+    python_requires='>=3.10',
     keywords=['development', 'OO']
     )


### PR DESCRIPTION
## Phase 3 of the repo refresh

Expand supported Python to 3.10-3.13 and unblock CI by upgrading the test toolchain.

### Commits
| SHA | Summary |
|---|---|
| `6277873` | `ci: expand matrix to Python 3.10-3.13 and add python_requires` |
| `bef32e7` | `build: upgrade pinned dev deps to versions compatible with Py 3.10+` |

### Scope adjustment
The initial commit (`6277873`) pushed the matrix change optimistically and, as predicted in the PR description, all four jobs failed — the ancient `pytest==4.6.11` is fundamentally incompatible with Python 3.10+:
- **3.10 / 3.11**: `TypeError: required field "lineno" missing from alias` — Py3.10 AST changes broke pytest's assertion rewriter
- **3.12**: `ModuleNotFoundError: No module named 'imp'` — `imp` was removed in 3.12
- **3.13**: same root cause as 3.12

The fix required upgrading the test toolchain, so commit `bef32e7` pulls the test-related portion of **Phase 5** forward.

### Changes

**`.github/workflows/python-app.yml`**
- Matrix: `["3.9"]` → `["3.10", "3.11", "3.12", "3.13"]`

**`setup.py`**
- Drop `:: 3.9` trove classifier; add `:: 3.10`, `:: 3.11`, `:: 3.12`, `:: 3.13`
- Add `python_requires='>=3.10'` (was absent)

**`Pipfile` [dev-packages]**
| Package | Before | After |
|---|---|---|
| `pytest` | `==4.6.11` | `>=8` |
| `pytest-cov` | `==2.10.1` | `>=5` |
| `pytest-forked` | `==1.3.0` | `>=1.6` |
| `pytest-timeout` | `==1.4.2` | `>=2` |
| `pytest-xdist` | `==1.34.0` | `>=3` |
| `coverage` | `==4.5.1` | `>=7` |
| `twine` | `==1.15` | unchanged (not on CI path) |

Ranges rather than pins because CI regenerates `Pipfile.lock` every run and `Pipfile` itself is scheduled for removal in Phase 4.

### Still deferred to Phase 5
- `twine` upgrade (release-only, not CI-blocking)
- `pylint` → `ruff` migration
- Any test-code updates needed to accommodate pytest 8 changes (none observed yet)

### Verification
Locally on Python 3.12 with the full CI pytest command:
```
172 passed, 76 xfailed in 1.17s
```
Same xfail count as master — no regressions.