### PR TITLE
Phase 6: code quality (ruff fixes, __all__, py.typed, format)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,8 @@ jobs:
         run: uv sync --group dev
       - name: Lint with ruff
         run: uv run ruff check do_py tests
+      - name: Check formatting with ruff
+        run: uv run ruff format --check do_py tests
       - name: Run unit tests
         run: |
           uv run pytest \

--- a/do_py/__init__.py
+++ b/do_py/__init__.py
@@ -1,4 +1,4 @@
 from .common import R
 from .data_object import DataObject
 
-__all__ = ["DataObject", "R"]
+__all__ = ['DataObject', 'R']

--- a/do_py/__init__.py
+++ b/do_py/__init__.py
@@ -1,2 +1,4 @@
 from .common import R
 from .data_object import DataObject
+
+__all__ = ["DataObject", "R"]

--- a/do_py/abc/__init__.py
+++ b/do_py/abc/__init__.py
@@ -13,6 +13,7 @@ class ABCRestrictionMeta(type):
     """
     TODO
     """
+
     _abc_classes = set()
     _unique_attrs = dict()
 
@@ -42,8 +43,9 @@ class ABCRestrictionMeta(type):
 
                 if fn_new:
                     # Run explicitly defined __new__
-                    assert callable(fn_new) or hasattr(fn_new, '__func__'), \
+                    assert callable(fn_new) or hasattr(fn_new, '__func__'), (
                         'Failed to decipher how to run nested __new__ for %s' % this_cls
+                    )
                     if callable(fn_new):
                         return fn_new(this_cls, *args, **kwargs)
                     elif hasattr(fn_new, '__func__'):
@@ -61,8 +63,9 @@ class ABCRestrictionMeta(type):
 
         if ConstABCR.required in namespace:
             # Root-type and Node-type classes define namespace requirements for its children.
-            assert namespace.get(ConstABCR.state, ConstABCR.root) in ConstABCR.restrictions_allowed, \
+            assert namespace.get(ConstABCR.state, ConstABCR.root) in ConstABCR.restrictions_allowed, (
                 'Invalid class type=%s' % namespace.get(ConstABCR.state, ConstABCR.root)
+            )
             namespace[ConstABCR.state] = namespace.get(ConstABCR.state, ConstABCR.root)
 
             cls = type.__new__(mcs, cls_name, parents, namespace)
@@ -95,8 +98,9 @@ class ABCRestrictionMeta(type):
             required_attrs = set(sum([getattr(p, ConstABCR.required, ()) for p in roots + nodes], ()))
             for attr in required_attrs:
                 # Check that the required attribute is defined in this class or a leaf that is a parent of this class.
-                assert any([hasattr(p, attr) for p in leaves + nodes]) or attr in namespace, \
+                assert any([hasattr(p, attr) for p in leaves + nodes]) or attr in namespace, (
                     SystemMessages.REQUIRED_FOR % (attr, cls_name)
+                )
 
             # Validate that the value given to a unique attribute is unique system-wide for that attribute.
             unique_attrs = set(sum([getattr(p, ConstABCR.unique, ()) for p in roots + nodes], ()))
@@ -112,8 +116,9 @@ class ABCRestrictionMeta(type):
                         mcs._unique_attrs[attr].remove(leaf)
                         continue
 
-                    assert namespace[attr] != getattr(leaf, attr), \
+                    assert namespace[attr] != getattr(leaf, attr), (
                         'Unique value "%s" has already been declared in class %s' % (namespace[attr], leaf.__name__)
+                    )
 
             cls = type.__new__(mcs, cls_name, parents, namespace)
 
@@ -156,8 +161,9 @@ class ABCRestrictions:
             :return:
             """
             assert cls_ref not in ABCRestrictionMeta.abc_classes, SystemMessages.CLASS_ALREADY_DEFINED
-            assert getattr(cls_ref, ConstABCR.state, ConstABCR.root) in ConstABCR.restrictions_allowed, \
+            assert getattr(cls_ref, ConstABCR.state, ConstABCR.root) in ConstABCR.restrictions_allowed, (
                 SystemMessages.RESTRICTIONS_ALLOWED
+            )
 
             # Manipulate the namespace of the declared class so that metaclass handles it properly
             namespace = dict(cls_ref.__dict__)
@@ -166,8 +172,7 @@ class ABCRestrictions:
 
             # Check if required attributes passed in are new
             r = already_declared(cls_ref, ConstABCR.required, required_attrs)
-            assert not r, SystemMessages.ATTRIBUTE_ALREADY_DECLARED % ('Required', r,
-                                                                       "%s's parents" % cls_ref.__name__)
+            assert not r, SystemMessages.ATTRIBUTE_ALREADY_DECLARED % ('Required', r, "%s's parents" % cls_ref.__name__)
             namespace[ConstABCR.required] = required_attrs + getattr(cls_ref, ConstABCR.required, ())
 
             # Check if uniqueness requirements are declared for some attributes
@@ -192,7 +197,7 @@ class ABCRestrictions:
             else:
                 raise Exception(
                     'Metaclass ambiguity. Cannot use `ABCRestrictions.require` with %s.' % cls_type.__name__
-                    )
+                )
 
             return meta(cls_ref.__name__, cls_ref.__bases__, namespace)
 

--- a/do_py/abc/constants.py
+++ b/do_py/abc/constants.py
@@ -3,10 +3,12 @@ Constants to support base_model modules.
 :date_created: 2018-12-05
 """
 
+
 class ConstABCR:
     """
     Constants supporting ABCRestrictions
     """
+
     required = '_required_'
     unique = '_unique_'
     metaclass = '__metaclass__'

--- a/do_py/abc/messages.py
+++ b/do_py/abc/messages.py
@@ -4,6 +4,7 @@ System messages to directly support error messages in base_model modules.
 :author: Tim Davis
 """
 
+
 class SystemMessages:
     REQUIRED_FOR = '%s is required for %s!'
     GENERIC = 'Unknown error.'

--- a/do_py/common/__init__.py
+++ b/do_py/common/__init__.py
@@ -2,6 +2,7 @@
 Commonly used restrictions.
 :date_created: 2020-06-28
 """
+
 from datetime import date, datetime
 
 from do_py.data_object import Restriction

--- a/do_py/common/managed_datetime.py
+++ b/do_py/common/managed_datetime.py
@@ -33,16 +33,11 @@ class MgdDatetime(ManagedRestrictions):
         A(data={'from_date': None}, strict=False)  # {"from_date": "1969-12-31"}
         A({'from_date': None})  # {"from_date": "1969-12-31"}
     """
+
     dt_obj = None
     _restriction = R()
-    _parse_dt_fmt = {
-        datetime: '%Y-%m-%dT%H:%M:%S',
-        date: '%Y-%m-%d'
-        }
-    defaults = {
-        'from': lambda dt: dt.fromtimestamp(0),
-        'to': lambda dt: dt.now() if dt is datetime else dt.today()
-        }
+    _parse_dt_fmt = {datetime: '%Y-%m-%dT%H:%M:%S', date: '%Y-%m-%d'}
+    defaults = {'from': lambda dt: dt.fromtimestamp(0), 'to': lambda dt: dt.now() if dt is datetime else dt.today()}
 
     def __init__(self, dt_obj=None, default_key=None, nullable=False, *args, **kwargs):
         """

--- a/do_py/common/managed_datetime.py
+++ b/do_py/common/managed_datetime.py
@@ -74,8 +74,8 @@ class MgdDatetime(ManagedRestrictions):
         elif type(self.data) not in [datetime, date]:
             try:
                 self.data = datetime.strptime(self.data, self._parse_dt_fmt[self.dt_obj])
-            except ValueError:
-                raise RestrictionError.bad_data(self.data, self.dt_obj)
+            except ValueError as e:
+                raise RestrictionError.bad_data(self.data, self.dt_obj) from e
             if self.dt_obj is date:
                 self.data = self.data.date()
 

--- a/do_py/common/managed_list.py
+++ b/do_py/common/managed_list.py
@@ -1,6 +1,7 @@
 """
 :date_created: 2020-06-28
 """
+
 from do_py.common import R
 from do_py.data_object.restriction import ManagedRestrictions
 from do_py.exceptions import RestrictionError
@@ -10,6 +11,7 @@ class ManagedList(ManagedRestrictions):
     """
     Use this when you need a restriction for a list of DataObject's.
     """
+
     _restriction = R(list, type(None))
 
     @property
@@ -43,7 +45,6 @@ class ManagedList(ManagedRestrictions):
 
 # TODO: Unit tests
 class OrderedManagedList(ManagedList):
-
     def __init__(self, obj_cls, nullable=False, key=None, reverse=False):
         """
         :param obj_cls: DataObject class reference to wrap each object in list.

--- a/do_py/data_object/__init__.py
+++ b/do_py/data_object/__init__.py
@@ -140,7 +140,7 @@ class DataObject(RestrictedDictMixin):
         return dict(self)
 
     # TODO: Needs a test
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict=None):
         """
         Supports deep copying of DataObject. This gives user back plain old python dictionary.
         :param memodict:
@@ -148,6 +148,8 @@ class DataObject(RestrictedDictMixin):
         :return: python dictionary representation
         :rtype: dict
         """
+        if memodict is None:
+            memodict = {}
         # NOTE: this could be an alternative implementation
         # return self.__class__(data=dict(self))
         memodict[id(self)] = self.__copy__()

--- a/do_py/data_object/__init__.py
+++ b/do_py/data_object/__init__.py
@@ -51,7 +51,7 @@ class DataObject(RestrictedDictMixin):
             try:
                 cls._restrictions[k] = Restriction.legacy(cls._restrictions[k])
             except RestrictionError as e:
-                raise DataObjectError.from_restriction_error(k, cls, e)
+                raise DataObjectError.from_restriction_error(k, cls, e) from e
 
     @classmethod
     def _validate_data(cls, _restrictions, d, strict=True):
@@ -98,7 +98,7 @@ class DataObject(RestrictedDictMixin):
                 try:
                     _dict[k] = v(d[k], strict=strict)
                 except RestrictionError as e:
-                    raise DataObjectError.from_restriction_error(k, cls, e)
+                    raise DataObjectError.from_restriction_error(k, cls, e) from e
 
         return _dict
 

--- a/do_py/data_object/__init__.py
+++ b/do_py/data_object/__init__.py
@@ -37,6 +37,7 @@ class DataObject(RestrictedDictMixin):
 
     :attribute _restrictions: dictionary defining data structure and valid values.
     """
+
     _schema = None
 
     @classmethod

--- a/do_py/data_object/dynamic_restrictions.py
+++ b/do_py/data_object/dynamic_restrictions.py
@@ -3,6 +3,7 @@ Dynamic restrictions for a DataObject.
 :date_created: 2020-07-10
 :author: Gian Brazzini
 """
+
 import copy
 
 from do_py import DataObject, R
@@ -16,6 +17,7 @@ class DynamicRestrictions(ManagedRestrictions):
     A dict that contains the dynamic restrictions where the key is the independent
     key's value and the value is the dependent key's restriction.
     """
+
     _restriction = R()
 
     def manage(self):
@@ -34,11 +36,8 @@ class DynamicClassGenerator(DataObject):
     :restriction dependent_key: The key where the restriction is dynamic.
     :restriction dynamic_restrictions: See `DynamicRestrictions` ManagedList.
     """
-    _restrictions = {
-        'independent_key': R.STR,
-        'dependent_key': R.STR,
-        'dynamic_restrictions': DynamicRestrictions()
-        }
+
+    _restrictions = {'independent_key': R.STR, 'dependent_key': R.STR, 'dynamic_restrictions': DynamicRestrictions()}
 
     @property
     def update_fn_name(self):
@@ -72,7 +71,7 @@ class DynamicClassGenerator(DataObject):
             '_is_abstract_': True,
             '__module__': self.__class__.__module__,
             self.update_fn_name: update_restriction,
-            }
+        }
 
         # Create the class using ABCRestrictionMeta as the metaclass and inheriting from DataObject.
         return ABCRestrictionMeta('dynamic_%s_mixin' % self.dependent_key, (DataObject,), attributes)
@@ -124,19 +123,23 @@ class DynamicClassGenerator(DataObject):
             super(self.dynamic_class, cls).__compile__()
 
             # Validate that the independent and dependent keys must exist in the restrictions.
-            assert self.independent_key in cls._restrictions, \
+            assert self.independent_key in cls._restrictions, (
                 '%s.%s required in restrictions for dynamic restrictions.' % (cls.__name__, self.independent_key)
-            assert self.dependent_key in cls._restrictions, \
+            )
+            assert self.dependent_key in cls._restrictions, (
                 '%s.%s required in restrictions for dynamic restrictions.' % (cls.__name__, self.dependent_key)
+            )
 
             # Validate that the independent restriction is a list value restriction.
             independent_key_restriction = cls._restrictions[self.independent_key]
-            assert isinstance(independent_key_restriction, _ListValueRestriction), \
+            assert isinstance(independent_key_restriction, _ListValueRestriction), (
                 'The independent key must be of type `_ListValueRestriction`.'
+            )
 
             # Validate that all values for the independent restrictions are accounted for in the dynamic restrictions.
-            assert len(independent_key_restriction[0]) == len(self.dynamic_restrictions), \
+            assert len(independent_key_restriction[0]) == len(self.dynamic_restrictions), (
                 'All restrictions must be accounted for when creating dynamic restrictions.'
+            )
             for value in independent_key_restriction[0]:
                 assert value in self.dynamic_restrictions, 'Missing dynamic restriction for value "%s".' % value
 
@@ -165,8 +168,10 @@ def dynamic_restriction_mixin(independent_key, dependent_key, **kwargs):
     :param kwargs: The dynamic restrictions.
     :rtype: type(DataObject)
     """
-    return DynamicClassGenerator({
-        'independent_key': independent_key,
-        'dependent_key': dependent_key,
-        'dynamic_restrictions': kwargs,
-        }).mixin
+    return DynamicClassGenerator(
+        {
+            'independent_key': independent_key,
+            'dependent_key': dependent_key,
+            'dynamic_restrictions': kwargs,
+        }
+    ).mixin

--- a/do_py/data_object/restricted_dict.py
+++ b/do_py/data_object/restricted_dict.py
@@ -82,8 +82,8 @@ class RestrictedDictMixin(dict):
         """
         try:
             return self[item]
-        except KeyError:
-            raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, item))
+        except KeyError as e:
+            raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, item)) from e
 
     def __dir__(self):
         dict_dir = dir(type(self))

--- a/do_py/data_object/restriction.py
+++ b/do_py/data_object/restriction.py
@@ -29,6 +29,7 @@ class AbstractRestriction(tuple):
     default:
     Every restriction provides a default value. If not explicitly specified, it is implicitly set to None.
     """
+
     _default = None
     _allowed = None
 
@@ -126,6 +127,7 @@ class SingletonRestriction(AbstractRestriction):
     This is an interface for Restriction type to use singleton structure. The objective is to use pre-defined
     restrictions and reduce the memory footprint of DataObject declarations.
     """
+
     _cache = {}
 
     def __new__(cls, restriction_tuple):
@@ -449,11 +451,7 @@ class _NullableDataObjectRestriction(SingletonRestriction):
         if hasattr(self.dataobj, 'es_restrictions'):
             return self.dataobj.es_restrictions
         else:
-            return {
-                'properties': {
-                    k: v.es_restrictions for k, v in self.dataobj._restrictions.items()
-                    }
-                }
+            return {'properties': {k: v.es_restrictions for k, v in self.dataobj._restrictions.items()}}
 
 
 class _DataObjectRestriction(_NullableDataObjectRestriction):
@@ -616,6 +614,7 @@ class ManagedRestrictions(metaclass=ABCMeta):
 
     :attribute manage: users must implement validation/standardization logic in manage
     """
+
     data = None
 
     def __new__(cls, *args, **kwargs):
@@ -678,6 +677,7 @@ class ESR:
     """
     Constants class housing the different types of ES restrictions.
     """
+
     INT = {'type': 'integer'}
     FLOAT = {'type': 'float'}
     DATE = {'type': 'date'}
@@ -694,10 +694,7 @@ class ESR:
         """
         if not hasattr(nested_data_object, 'es_restrictions'):
             raise RestrictionError.bad_data(nested_data_object, 'DataObject')
-        return {
-            'type': 'object',
-            'properties': nested_data_object.es_restrictions
-            }
+        return {'type': 'object', 'properties': nested_data_object.es_restrictions}
 
     @staticmethod
     def NESTED(nested_data_object):
@@ -708,10 +705,7 @@ class ESR:
         """
         if not hasattr(nested_data_object, 'es_restrictions'):
             raise RestrictionError.bad_data(nested_data_object, 'DataObject')
-        return {
-            'type': 'nested',
-            'properties': nested_data_object.es_restrictions
-            }
+        return {'type': 'nested', 'properties': nested_data_object.es_restrictions}
 
 
 class ESEncoder:
@@ -734,7 +728,7 @@ class ESEncoder:
             str: ESR.STR,
             'keyword': ESR.KEYWORD,
             # list: {},
-            }
+        }
 
     @classmethod
     def default(cls, obj):

--- a/do_py/data_object/restriction.py
+++ b/do_py/data_object/restriction.py
@@ -151,8 +151,8 @@ class SingletonRestriction(AbstractRestriction):
                 hashable = (cls.__name__, restriction_tuple[0])
             else:
                 hashable = (cls.__name__, frozenset(restriction_tuple[0]), rt1)
-        except TypeError:
-            raise RestrictionError.from_unhashable(restriction_tuple[0], restriction_tuple[1])
+        except TypeError as e:
+            raise RestrictionError.from_unhashable(restriction_tuple[0], restriction_tuple[1]) from e
 
         if hashable in cls._cache:
             return cls._cache[hashable]
@@ -740,5 +740,5 @@ class ESEncoder:
     def default(cls, obj):
         try:
             return cls.encoding[obj]
-        except KeyError:
-            raise RestrictionError('%s cannot be encoded!' % obj)
+        except KeyError as e:
+            raise RestrictionError('%s cannot be encoded!' % obj) from e

--- a/do_py/data_object/restriction.py
+++ b/do_py/data_object/restriction.py
@@ -105,10 +105,12 @@ class AbstractRestriction(tuple):
     def __copy__(self):
         return tuple(self)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict=None):
         """
         NOTE: `deepcopy` uses memoization to store a previously copied instance.
         """
+        if memodict is None:
+            memodict = {}
         _r = copy.deepcopy(self.__copy__())
         instance = self.__class__(_r[0], default=_r[1])
         memodict[id(self)] = instance

--- a/do_py/data_object/validator.py
+++ b/do_py/data_object/validator.py
@@ -32,6 +32,7 @@ class Validator(DataObject):
 
     :attribute _validate: a validation function to validate data for mutually dependent keys
     """
+
     _is_abstract_ = True
 
     def __init__(self, data=None, strict=True):

--- a/do_py/exceptions/__init__.py
+++ b/do_py/exceptions/__init__.py
@@ -1,4 +1,4 @@
 from .data_object_error import DataObjectError
 from .restriction_error import RestrictionError
 
-__all__ = ["DataObjectError", "RestrictionError"]
+__all__ = ['DataObjectError', 'RestrictionError']

--- a/do_py/exceptions/__init__.py
+++ b/do_py/exceptions/__init__.py
@@ -1,2 +1,4 @@
 from .data_object_error import DataObjectError
 from .restriction_error import RestrictionError
+
+__all__ = ["DataObjectError", "RestrictionError"]

--- a/do_py/exceptions/data_object_error.py
+++ b/do_py/exceptions/data_object_error.py
@@ -26,4 +26,4 @@ class DataObjectError(Exception):
         Movation:
         Catch -> Rethrow to add more information that would save debugging time.
         """
-        return cls("%s.%s: %s" % (cls_ref.__name__, key, restriction_error))
+        return cls('%s.%s: %s' % (cls_ref.__name__, key, restriction_error))

--- a/do_py/utils/__init__.py
+++ b/do_py/utils/__init__.py
@@ -2,14 +2,15 @@
 Useful methods, classes, and tools.
 An important note on utils is that they should have no dependencies on the rest of the project.
 """
+
 from .json_encoder import MyJSONEncoder
 from .properties import cached_property, classproperty, is_cached_property, is_classmethod, is_property
 
 __all__ = [
-    "MyJSONEncoder",
-    "cached_property",
-    "classproperty",
-    "is_cached_property",
-    "is_classmethod",
-    "is_property",
+    'MyJSONEncoder',
+    'cached_property',
+    'classproperty',
+    'is_cached_property',
+    'is_classmethod',
+    'is_property',
 ]

--- a/do_py/utils/__init__.py
+++ b/do_py/utils/__init__.py
@@ -4,3 +4,12 @@ An important note on utils is that they should have no dependencies on the rest 
 """
 from .json_encoder import MyJSONEncoder
 from .properties import cached_property, classproperty, is_cached_property, is_classmethod, is_property
+
+__all__ = [
+    "MyJSONEncoder",
+    "cached_property",
+    "classproperty",
+    "is_cached_property",
+    "is_classmethod",
+    "is_property",
+]

--- a/do_py/utils/json_encoder.py
+++ b/do_py/utils/json_encoder.py
@@ -1,6 +1,7 @@
 """
 :date_created: 2019-08-01
 """
+
 import json
 from datetime import date, datetime
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ addopts = "-so xfail_strict=True --durations 10 --maxfail 10"
 line-length = 120
 target-version = "py310"
 
+[tool.ruff.format]
+# Preserve the codebase's existing single-quote style.
+quote-style = "single"
+
 [tool.ruff.lint]
 # Sensible default lint set without being too aggressive on a legacy
 # codebase. Phase 6 will broaden this and add type annotations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,13 +75,9 @@ select = [
 ignore = [
     "E501",   # line-too-long — line-length is advisory; long docstrings/URLs happen
     "E721",   # use isinstance() — DataObject intentionally uses `type(x) is T` for strict (non-subtype) checks
-    "E731",   # lambda assignment — a couple of intentional usages; Phase 6 will revisit
-    "B006",   # mutable default args — 2 real but non-urgent cases (deepcopy memodict); Phase 6
     "B008",   # function call in argument default — false positive heavy for dataclass-like APIs
-    "B904",   # use `raise X from Y` — broader exception handling cleanup in Phase 6
-    "B905",   # zip without strict=  — needs domain review; Phase 6
-    "UP031",  # printf-style formatting — pervasive in error-message templates; converting changes deferred-
-              # formatting semantics. Phase 6.
+    "UP031",  # printf-style formatting — pervasive in error-message templates; converting would change
+              # deferred-formatting semantics (templates are used as `MSG % args` at call sites).
     "UP008",  # super() without args — NOT safe on this codebase. The @ABCRestrictions.require decorator
               # rebuilds decorated classes via `meta(name, bases, namespace)`, which copies methods from
               # the original class's dict. Methods' implicit __class__ cell still references the ORIGINAL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,6 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Re-exports from package __init__.py look like unused imports to ruff.
-# Long-term we can add explicit __all__ or `X as X` syntax; for now,
-# ignore F401 in these specific files.
-"do_py/__init__.py" = ["F401"]
-"do_py/exceptions/__init__.py" = ["F401"]
-"do_py/utils/__init__.py" = ["F401"]
 "tests/**" = [
     "B011",  # `assert False` is idiomatic in some test patterns here
 ]

--- a/tests/data.py
+++ b/tests/data.py
@@ -5,11 +5,7 @@ from do_py.common import R
 
 
 class A(DataObject):
-    _restrictions = {
-        'id': R.INT,
-        'name': R.STR,
-        'status': R(0, 1, 2)
-        }
+    _restrictions = {'id': R.INT, 'name': R.STR, 'status': R(0, 1, 2)}
 
     @classmethod
     def create(cls, **kwargs):
@@ -20,21 +16,11 @@ data = [
     (1, 'pulseM', 0),
     (2, 'speetra', 2),
     pytest.param(2, True, 2, marks=pytest.mark.xfail),
-    pytest.param(2, 'pulseM', 3, marks=pytest.mark.xfail)
-    ]
+    pytest.param(2, 'pulseM', 3, marks=pytest.mark.xfail),
+]
 short_data = [data[0]]
-keys = [
-    'id',
-    'name',
-    'status',
-    pytest.param('random', marks=pytest.mark.xfail)
-    ]
-key_values = [
-    ('id', 1),
-    ('name', 'yay'),
-    ('status', 1),
-    pytest.param('random', 'random', marks=pytest.mark.xfail)
-    ]
+keys = ['id', 'name', 'status', pytest.param('random', marks=pytest.mark.xfail)]
+key_values = [('id', 1), ('name', 'yay'), ('status', 1), pytest.param('random', 'random', marks=pytest.mark.xfail)]
 
 
 class MyTestException(Exception):

--- a/tests/test_abc_restrictions.py
+++ b/tests/test_abc_restrictions.py
@@ -2,7 +2,6 @@
 :date_created: 2019-08-20
 """
 
-
 import pytest
 
 from do_py.abc import ABCRestrictionMeta, ABCRestrictions
@@ -12,7 +11,6 @@ from .data import MyTestException
 
 
 class TestABCRestrictions:
-
     @pytest.mark.parametrize('def_new', [False, True])
     def test_require_decorator(self, def_new):
         def __new__():
@@ -43,8 +41,7 @@ class TestABCRestrictions:
         assert SubOk
         assert SubOk.x == 1
 
-        MiddleLayerOk = type('MiddleLayerOk', (RestrictedOk,), {ConstABCR.is_abstract: True,
-                                                                '__module__': __name__})
+        MiddleLayerOk = type('MiddleLayerOk', (RestrictedOk,), {ConstABCR.is_abstract: True, '__module__': __name__})
         assert MiddleLayerOk
         assert 'x' not in MiddleLayerOk.__dict__
 

--- a/tests/test_common/test_esr.py
+++ b/tests/test_common/test_esr.py
@@ -2,7 +2,6 @@
 :date_created: 2020-06-28
 """
 
-
 import pytest
 
 from do_py import DataObject
@@ -30,17 +29,11 @@ class TestESR:
         """
 
         class SampleDO(DataObject):
-            _restrictions = {
-                'x': R.INT
-                }
-            es_restrictions = {
-                'x': ESR.INT
-                }
+            _restrictions = {'x': R.INT}
+            es_restrictions = {'x': ESR.INT}
 
         class BadSampleDO(DataObject):
-            _restrictions = {
-                'x': R.INT
-                }
+            _restrictions = {'x': R.INT}
 
         return SampleDO({'x': 1}) if request.param else BadSampleDO
 
@@ -60,8 +53,9 @@ class TestESR:
 
 
 class TestESEncoder:
-
-    @pytest.mark.parametrize('datatype, mapping',
-                             list(ESEncoder.encoding.items()) + [pytest.param(ESEncoder, None, marks=pytest.mark.xfail())])
+    @pytest.mark.parametrize(
+        'datatype, mapping',
+        list(ESEncoder.encoding.items()) + [pytest.param(ESEncoder, None, marks=pytest.mark.xfail())],
+    )
     def test_encoding(self, datatype, mapping):
         assert ESEncoder.default(datatype) == mapping

--- a/tests/test_common/test_managed_datetime.py
+++ b/tests/test_common/test_managed_datetime.py
@@ -1,6 +1,7 @@
 """
 :date_created: 2020-06-28
 """
+
 from datetime import date, datetime
 
 import pytest
@@ -20,18 +21,17 @@ class TestMgdDatetime:
     Test the instantiation and usages of the managed datetime object.
     """
 
-    @pytest.mark.parametrize('dt_obj, nullable, expected_restriction', [
-        (datetime, False, R.DATETIME),
-        (datetime, True, R.NULL_DATETIME),
-        (date, False, R.DATE),
-        (date, True, R.NULL_DATE),
-        pytest.param(None, True, None, marks=pytest.mark.xfail(raises=AssertionError))
-        ])
-    @pytest.mark.parametrize('default_key', [
-        'to',
-        'from',
-        None
-        ])
+    @pytest.mark.parametrize(
+        'dt_obj, nullable, expected_restriction',
+        [
+            (datetime, False, R.DATETIME),
+            (datetime, True, R.NULL_DATETIME),
+            (date, False, R.DATE),
+            (date, True, R.NULL_DATE),
+            pytest.param(None, True, None, marks=pytest.mark.xfail(raises=AssertionError)),
+        ],
+    )
+    @pytest.mark.parametrize('default_key', ['to', 'from', None])
     def test_restriction(self, dt_obj, nullable, expected_restriction, default_key):
         """
         The correct restriction should be used depending on dt_obj and nullable.
@@ -40,11 +40,14 @@ class TestMgdDatetime:
         if instance._restriction != expected_restriction:
             raise Exception('instance._restriction != expected_restriction')
 
-    @pytest.mark.parametrize('input, output', [
-        (test_dt_instance, test_dt_instance),
-        (test_dt_instance.isoformat(), test_dt_instance),
-        (None, test_dt_instance_epoch)
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_dt_instance, test_dt_instance),
+            (test_dt_instance.isoformat(), test_dt_instance),
+            (None, test_dt_instance_epoch),
+        ],
+    )
     def test_from_datetime(self, input, output):
         """
         :type input: datetime or str or None
@@ -53,11 +56,14 @@ class TestMgdDatetime:
         instance = MgdDatetime.from_from_datetime()
         assert output == instance(input)
 
-    @pytest.mark.parametrize('input, output', [
-        (test_date_instance_now, test_date_instance_now),
-        (test_date_instance_now.isoformat(), test_date_instance_now),
-        (None, test_dt_instance_epoch.date())
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_date_instance_now, test_date_instance_now),
+            (test_date_instance_now.isoformat(), test_date_instance_now),
+            (None, test_dt_instance_epoch.date()),
+        ],
+    )
     def test_from_date(self, input, output):
         """
         :type input: date or str or None
@@ -66,12 +72,15 @@ class TestMgdDatetime:
         instance = MgdDatetime.from_from_date()
         assert instance(input) == output
 
-    @pytest.mark.parametrize('input, output', [
-        (test_dt_instance_now, test_dt_instance_now),
-        (test_dt_instance_now.isoformat(), test_dt_instance_now),
-        # This creates race condition.
-        # pytest.param(None, test_dt_instance_now, marks=pytest.mark.xfail(raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_dt_instance_now, test_dt_instance_now),
+            (test_dt_instance_now.isoformat(), test_dt_instance_now),
+            # This creates race condition.
+            # pytest.param(None, test_dt_instance_now, marks=pytest.mark.xfail(raises=RestrictionError))
+        ],
+    )
     def test_to_datetime(self, input, output):
         """
         :type input: datetime or str or None
@@ -80,11 +89,14 @@ class TestMgdDatetime:
         instance = MgdDatetime.from_to_datetime()
         assert instance(input) == output
 
-    @pytest.mark.parametrize('input, output', [
-        (test_date_instance_now, test_date_instance_now),
-        (test_date_instance_now.isoformat(), test_dt_instance_now.date()),
-        (None, test_date_instance_now)
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_date_instance_now, test_date_instance_now),
+            (test_date_instance_now.isoformat(), test_dt_instance_now.date()),
+            (None, test_date_instance_now),
+        ],
+    )
     def test_to_date(self, input, output):
         """
         Test the classmethod `datetime` validates date ISO format properly and handles None.
@@ -94,14 +106,20 @@ class TestMgdDatetime:
         instance = MgdDatetime.from_to_date()
         assert output == instance(input)
 
-    @pytest.mark.parametrize('input, output', [
-        (test_dt_instance_now, test_dt_instance_now),
-        (test_dt_instance_now.isoformat(), test_dt_instance_now),
-        pytest.param(test_date_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(test_date_instance_now.isoformat(), test_dt_instance_now,
-                     marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(None, None, marks=pytest.mark.xfail(raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_dt_instance_now, test_dt_instance_now),
+            (test_dt_instance_now.isoformat(), test_dt_instance_now),
+            pytest.param(test_date_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+            pytest.param(
+                test_date_instance_now.isoformat(),
+                test_dt_instance_now,
+                marks=pytest.mark.xfail(raises=RestrictionError),
+            ),
+            pytest.param(None, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+        ],
+    )
     def test_datetime(self, input, output):
         """
         Test the classmethod `datetime` validates date ISO format properly and handles None.
@@ -111,14 +129,20 @@ class TestMgdDatetime:
         instance = MgdDatetime.datetime()
         assert instance(input) == output
 
-    @pytest.mark.parametrize('input, output', [
-        (test_dt_instance_now, test_dt_instance_now),
-        (test_dt_instance_now.isoformat(), test_dt_instance_now),
-        pytest.param(test_date_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(test_date_instance_now.isoformat(), test_dt_instance_now,
-                     marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(None, None)
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_dt_instance_now, test_dt_instance_now),
+            (test_dt_instance_now.isoformat(), test_dt_instance_now),
+            pytest.param(test_date_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+            pytest.param(
+                test_date_instance_now.isoformat(),
+                test_dt_instance_now,
+                marks=pytest.mark.xfail(raises=RestrictionError),
+            ),
+            pytest.param(None, None),
+        ],
+    )
     def test_null_datetime(self, input, output):
         """
         Test the classmethod `null_datetime` validates date ISO format properly and handles None.
@@ -128,14 +152,20 @@ class TestMgdDatetime:
         instance = MgdDatetime.null_datetime()
         assert instance(input) == output
 
-    @pytest.mark.parametrize('input, output', [
-        (test_date_instance_now, test_date_instance_now),
-        (test_date_instance_now.isoformat(), test_date_instance_now),
-        pytest.param(test_dt_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(test_dt_instance_now.isoformat(), test_date_instance_now,
-                     marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(None, None, marks=pytest.mark.xfail(raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_date_instance_now, test_date_instance_now),
+            (test_date_instance_now.isoformat(), test_date_instance_now),
+            pytest.param(test_dt_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+            pytest.param(
+                test_dt_instance_now.isoformat(),
+                test_date_instance_now,
+                marks=pytest.mark.xfail(raises=RestrictionError),
+            ),
+            pytest.param(None, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+        ],
+    )
     def test_date(self, input, output):
         """
         Test the classmethod `date` validates date ISO format properly and handles None.
@@ -145,14 +175,20 @@ class TestMgdDatetime:
         instance = MgdDatetime.date()
         assert instance(input) == output
 
-    @pytest.mark.parametrize('input, output', [
-        (test_date_instance_now, test_date_instance_now),
-        (test_date_instance_now.isoformat(), test_date_instance_now),
-        pytest.param(test_dt_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
-        pytest.param(test_dt_instance_now.isoformat(), test_date_instance_now,
-                     marks=pytest.mark.xfail(raises=RestrictionError)),
-        (None, None)
-        ])
+    @pytest.mark.parametrize(
+        'input, output',
+        [
+            (test_date_instance_now, test_date_instance_now),
+            (test_date_instance_now.isoformat(), test_date_instance_now),
+            pytest.param(test_dt_instance_now, None, marks=pytest.mark.xfail(raises=RestrictionError)),
+            pytest.param(
+                test_dt_instance_now.isoformat(),
+                test_date_instance_now,
+                marks=pytest.mark.xfail(raises=RestrictionError),
+            ),
+            (None, None),
+        ],
+    )
     def test_null_date(self, input, output):
         """
         Test the classmethod `null_date` validates date ISO format properly and handles None.

--- a/tests/test_common/test_managed_list.py
+++ b/tests/test_common/test_managed_list.py
@@ -2,7 +2,6 @@
 :date_created: 2020-06-28
 """
 
-
 import pytest
 
 from do_py import DataObject
@@ -11,62 +10,37 @@ from do_py.common.managed_list import ManagedList
 
 
 class Book(DataObject):
-    _restrictions = {
-        'title': R.STR,
-        'author': R.STR
-        }
+    _restrictions = {'title': R.STR, 'author': R.STR}
 
 
 class Bookshelf(DataObject):
-    _restrictions = {
-        'type': ['wood', 'metal'],
-        'size': ['small', 'medium', 'large']
-        }
+    _restrictions = {'type': ['wood', 'metal'], 'size': ['small', 'medium', 'large']}
 
 
 class Library(DataObject):
-    _restrictions = {
-        'books': ManagedList(Book),
-        'shelves': ManagedList(Bookshelf, nullable=True)
-        }
+    _restrictions = {'books': ManagedList(Book), 'shelves': ManagedList(Bookshelf, nullable=True)}
 
 
 class TestManagedList:
-    book_1 = {
-        'title': '1',
-        'author': 'Author 1'
-        }
-    book_2 = {
-        'title': '2',
-        'author': 'Author 2'
-        }
-    shelf_1 = {
-        'type': 'wood',
-        'size': 'small'
-        }
-    shelf_2 = {
-        'type': 'metal',
-        'size': 'large'
-        }
+    book_1 = {'title': '1', 'author': 'Author 1'}
+    book_2 = {'title': '2', 'author': 'Author 2'}
+    shelf_1 = {'type': 'wood', 'size': 'small'}
+    shelf_2 = {'type': 'metal', 'size': 'large'}
 
-    @pytest.mark.parametrize('books', [
-        pytest.param(None, marks=pytest.mark.xfail),
-        [],
-        [book_1],
-        [Book(book_1)],
-        [book_1, book_2],
-        [Book(book_1), Book(book_2)]
-        ])
-    @pytest.mark.parametrize('shelves', [
-        None,
-        [],
-        [shelf_1],
-        [Bookshelf(shelf_1)],
-        [shelf_1, shelf_2],
-        [Bookshelf(shelf_1), Bookshelf(shelf_2)]
-        ])
+    @pytest.mark.parametrize(
+        'books',
+        [
+            pytest.param(None, marks=pytest.mark.xfail),
+            [],
+            [book_1],
+            [Book(book_1)],
+            [book_1, book_2],
+            [Book(book_1), Book(book_2)],
+        ],
+    )
+    @pytest.mark.parametrize(
+        'shelves',
+        [None, [], [shelf_1], [Bookshelf(shelf_1)], [shelf_1, shelf_2], [Bookshelf(shelf_1), Bookshelf(shelf_2)]],
+    )
     def test_managed_list(self, books, shelves):
-        assert Library({
-            'books': books,
-            'shelves': shelves
-            })
+        assert Library({'books': books, 'shelves': shelves})

--- a/tests/test_common/test_r.py
+++ b/tests/test_common/test_r.py
@@ -2,22 +2,23 @@
 :date_created: 2020-06-28
 """
 
-
 import pytest
 
 from do_py.common import R
 
 
 class TestR:
-
     @pytest.mark.parametrize('attr', [r for r in dir(R) if not r.startswith('__')])
     def test_r_constants(self, attr):
         assert getattr(R, attr)
 
-    @pytest.mark.parametrize('args, kwargs', [
-        ([], {}),
-        ([int], {}),
-        ([int], {'default': 1}),
-        ])
+    @pytest.mark.parametrize(
+        'args, kwargs',
+        [
+            ([], {}),
+            ([int], {}),
+            ([int], {'default': 1}),
+        ],
+    )
     def test_r_creation(self, args, kwargs):
         assert R(*args, **kwargs)

--- a/tests/test_data_object/test_data_object.py
+++ b/tests/test_data_object/test_data_object.py
@@ -25,7 +25,6 @@ def our_hasattr(instance, name):
 
 
 class TestDataObject:
-
     @pytest.mark.parametrize('id, name, status', data)
     def test_init(self, id, name, status):
         a = A.create(id=id, name=name, status=status)
@@ -40,10 +39,9 @@ class TestDataObject:
 
     def test_class_namespace(self):
         try:
+
             class B(DataObject):
-                _restrictions = {
-                    'x': R.INT.with_default(1)
-                    }
+                _restrictions = {'x': R.INT.with_default(1)}
                 x = None
 
             B(data={'x': 1})
@@ -53,21 +51,17 @@ class TestDataObject:
         except Exception as e:
             assert False, str(e)
 
-    @pytest.mark.parametrize('deep', [
-        pytest.param(True, marks=pytest.mark.xfail(raises=DataObjectError), id='deep'),
-        pytest.param(False, id='!deep')
-        ])
+    @pytest.mark.parametrize(
+        'deep',
+        [
+            pytest.param(True, marks=pytest.mark.xfail(raises=DataObjectError), id='deep'),
+            pytest.param(False, id='!deep'),
+        ],
+    )
     def test_deep_restriction(self, deep):
-        restric = {
-            'id': [0, 1, 2],
-            'x': R.INT.with_default(1),
-            'y': []
-            }
+        restric = {'id': [0, 1, 2], 'x': R.INT.with_default(1), 'y': []}
         if deep:
-            restric['deep'] = {
-                'this': [],
-                'fails': R(1, 2, 3, default=1)
-                }
+            restric['deep'] = {'this': [], 'fails': R(1, 2, 3, default=1)}
 
         class B(DataObject):
             _restrictions = restric
@@ -75,60 +69,44 @@ class TestDataObject:
     @pytest.mark.xfail(raises=DataObjectError)
     def test_malformed_restrictions(self):
         class FailsMalformed(DataObject):
-            _restrictions = {
-                'malformed': None
-                }
+            _restrictions = {'malformed': None}
 
     @pytest.mark.xfail(raises=RestrictionError)
     def test_mixed_restrictions(self):
         class FailsMixed(DataObject):
-            _restrictions = {
-                'mixed': R(int, 1, 2)
-                }
+            _restrictions = {'mixed': R(int, 1, 2)}
 
-    @pytest.mark.parametrize('restriction', [
-        [bool],
-        ([bool], None)
-        ])
+    @pytest.mark.parametrize('restriction', [[bool], ([bool], None)])
     @pytest.mark.xfail(raises=DataObjectError)
     def test_legacy_restrictions(self, restriction):
         class FailsLegacy(DataObject):
-            _restrictions = {
-                'legacy': restriction
-                }
+            _restrictions = {'legacy': restriction}
 
     @pytest.mark.xfail(raises=RestrictionError)
     def test_int_default(self):
         class FailsIntDefault(DataObject):
-            _restrictions = {
-                'int_default': R(default=int)
-                }
+            _restrictions = {'int_default': R(default=int)}
 
-    @pytest.mark.parametrize('d, strict, key', [
-        pytest.param(True, True, 'extra', marks=pytest.mark.xfail(raises=DataObjectError), id='d-strict-extra'),
-        pytest.param(True, True, 'missing', marks=pytest.mark.xfail(raises=DataObjectError), id='d-strict-missing'),
-        pytest.param(True, True, None, id='d-strict-None'),
-        pytest.param(True, False, 'extra', marks=pytest.mark.xfail(raises=DataObjectError), id='d-!strict-extra'),
-        pytest.param(True, False, 'missing', id='d-!strict-missing'),
-        pytest.param(True, False, None, id='d-!strict-None'),
-        pytest.param(False, True, None, marks=pytest.mark.xfail(raises=DataObjectError), id='!d-strict-None'),
-        pytest.param(False, False, None, id='!d-!strict-None')
-        ])
+    @pytest.mark.parametrize(
+        'd, strict, key',
+        [
+            pytest.param(True, True, 'extra', marks=pytest.mark.xfail(raises=DataObjectError), id='d-strict-extra'),
+            pytest.param(True, True, 'missing', marks=pytest.mark.xfail(raises=DataObjectError), id='d-strict-missing'),
+            pytest.param(True, True, None, id='d-strict-None'),
+            pytest.param(True, False, 'extra', marks=pytest.mark.xfail(raises=DataObjectError), id='d-!strict-extra'),
+            pytest.param(True, False, 'missing', id='d-!strict-missing'),
+            pytest.param(True, False, None, id='d-!strict-None'),
+            pytest.param(False, True, None, marks=pytest.mark.xfail(raises=DataObjectError), id='!d-strict-None'),
+            pytest.param(False, False, None, id='!d-!strict-None'),
+        ],
+    )
     def test_restrictions_runtime(self, d, strict, key):
-        restric = {
-            'id': R(0, 1, 2),
-            'x': R.INT.with_default(1),
-            'y': R()
-            }
+        restric = {'id': R(0, 1, 2), 'x': R.INT.with_default(1), 'y': R()}
 
         class B(DataObject):
             _restrictions = restric
 
-        data_ = {
-            'id': 0,
-            'x': 2,
-            'y': 'hi'
-            }
+        data_ = {'id': 0, 'x': 2, 'y': 'hi'}
         if key == 'extra':
             data_['z'] = None
         elif key == 'missing':
@@ -143,25 +121,12 @@ class TestDataObject:
             _restrictions = {
                 'x': R(1, 2),
                 'y': R.INT.with_default(100),
-                }
+            }
 
         class C(DataObject):
-            _restrictions = {
-                'a': A,
-                'b': B
-                }
+            _restrictions = {'a': A, 'b': B}
 
-        data_ = {
-            'a': {
-                'id': 1,
-                'name': 'evil-jenkins',
-                'status': 0
-                },
-            'b': {
-                'x': 1,
-                'y': 23
-                }
-            }
+        data_ = {'a': {'id': 1, 'name': 'evil-jenkins', 'status': 0}, 'b': {'x': 1, 'y': 23}}
         c = C(data=data_)
         assert c
         assert c.get('a') == c['a'] == c.a
@@ -195,50 +160,37 @@ class TestDataObject:
         for k, v in c_default.a.items():
             assert v is None, [(k, v) for k, v in c_default.a.items()]
 
-    @pytest.mark.parametrize('restrictions', [
-        pytest.param(R(A, type(None)), id='([A, type(None)], None)'),
-        A])
+    @pytest.mark.parametrize('restrictions', [pytest.param(R(A, type(None)), id='([A, type(None)], None)'), A])
     def test_supported_nested_restrictions_format(self, restrictions):
         class B(DataObject):
-            _restrictions = {
-                'a': restrictions
-                }
+            _restrictions = {'a': restrictions}
 
         class C(DataObject):
-            _restrictions = {
-                'b': B
-                }
+            _restrictions = {'b': B}
 
-        c = C(data={
-            'b': {
-                'a': A(data={
-                    'id': 1,
-                    'name': 'evil-jenkins',
-                    'status': 0
-                    })
-                }
-            })
+        c = C(data={'b': {'a': A(data={'id': 1, 'name': 'evil-jenkins', 'status': 0})}})
         assert c
         assert c.b
         assert c.b.a
         assert type(c.b.a) is A
 
-    @pytest.mark.parametrize('restrictions', [pytest.param((A, None),
-                                                           marks=pytest.mark.xfail(
-                                                               reason="'None' data not allowed for DO"),
-                                                           id='(A, None)'),
-                                              pytest.param(A, marks=pytest.mark.xfail)])
+    @pytest.mark.parametrize(
+        'restrictions',
+        [
+            pytest.param((A, None), marks=pytest.mark.xfail(reason="'None' data not allowed for DO"), id='(A, None)'),
+            pytest.param(A, marks=pytest.mark.xfail),
+        ],
+    )
     def test_null_nested_object(self, restrictions):
         class B(DataObject):
-            _restrictions = {
-                'a': restrictions
-                }
+            _restrictions = {'a': restrictions}
 
         b = B(data={'a': None})
         assert b
 
     def test_missing_restrictions(self):
         try:
+
             class B(DataObject):
                 pass
 
@@ -251,13 +203,9 @@ class TestDataObject:
 
     def test_nesting_dict_restrictions(self):
         try:
+
             class B(DataObject):
-                _restrictions = {
-                    'a': {
-                        'x': [],
-                        'y': []
-                        }
-                    }
+                _restrictions = {'a': {'x': [], 'y': []}}
 
             B(data={'a': {'x': 1, 'y': 2}})
             raise MyTestException('Error should have thrown.')
@@ -362,11 +310,7 @@ class TestDataObject:
         from datetime import date, datetime
 
         class B(DataObject):
-            _restrictions = {
-                'datetime': R.DATETIME,
-                'date': R.DATE,
-                'default': R()
-                }
+            _restrictions = {'datetime': R.DATETIME, 'date': R.DATE, 'default': R()}
 
         class MyObj(dict):
             pass
@@ -377,33 +321,26 @@ class TestDataObject:
         # __str__ returns string
         assert '%s' % a
 
-    @pytest.mark.parametrize('d, strict', [
-        ('valid', True),
-        pytest.param('invalid', True, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
-        pytest.param(None, True, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
-        pytest.param('partial', True, marks=pytest.mark.xfail(reason='Partial data not allowed when strict.')),
-        ('valid', False),
-        pytest.param('invalid', False, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
-        (None, False),
-        ('partial', False)
-        ])
+    @pytest.mark.parametrize(
+        'd, strict',
+        [
+            ('valid', True),
+            pytest.param('invalid', True, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
+            pytest.param(None, True, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
+            pytest.param('partial', True, marks=pytest.mark.xfail(reason='Partial data not allowed when strict.')),
+            ('valid', False),
+            pytest.param('invalid', False, marks=pytest.mark.xfail(reason='Data does not meet restrictions')),
+            (None, False),
+            ('partial', False),
+        ],
+    )
     def test_strict(self, d, strict):
         if d == 'valid':
-            d = {
-                'id': short_data[0][0],
-                'name': short_data[0][1],
-                'status': short_data[0][2]
-                }
+            d = {'id': short_data[0][0], 'name': short_data[0][1], 'status': short_data[0][2]}
         elif d == 'invalid':
-            d = {
-                'id': None,
-                'name': None,
-                'status': None
-                }
+            d = {'id': None, 'name': None, 'status': None}
         elif d == 'partial':
-            d = {
-                'id': 1
-                }
+            d = {'id': 1}
 
         a = A(data=d, strict=strict)
         assert a, '__init__ failed!'
@@ -433,13 +370,7 @@ class TestDataObject:
             _restrictions = {'id': R.INT}
 
         try:
-            type('Mixed',
-                 (DataObject,),
-                 {
-                     '_restrictions': {'id': [First, Second]},
-                     '__module__': 'pytest'
-                     }
-                 )
+            type('Mixed', (DataObject,), {'_restrictions': {'id': [First, Second]}, '__module__': 'pytest'})
             raise MyTestException('Mixed Data Objects should not be allowed in restrictions')
         except DataObjectError:
             assert True

--- a/tests/test_data_object/test_deepcopy.py
+++ b/tests/test_data_object/test_deepcopy.py
@@ -1,6 +1,7 @@
 """
 :date_created: 2021-09-23
 """
+
 from copy import deepcopy
 
 from do_py import R
@@ -11,11 +12,12 @@ class Address(DataObject):
     """
     DataObject to standardize address representation and storage. Validates if state belongs to country.
     """
+
     _restrictions = {
         'street': R.STR,
         'street2': R.NULL_STR,
         'city': R.STR,
-        }
+    }
 
 
 class TestDataObjectCopy:

--- a/tests/test_data_object/test_dynamic_restrictions.py
+++ b/tests/test_data_object/test_dynamic_restrictions.py
@@ -2,6 +2,7 @@
 Test dynamic restriction class creation, inheritance and usage.
 :date_created: 2020-07-10
 """
+
 import pytest
 
 from do_py import DataObject, R
@@ -12,18 +13,16 @@ class MilkMetadata(DataObject):
     """
     Full of vitamins and minerals
     """
-    _restrictions = {
-        'flavor': R('chocolate', 'normal')
-        }
+
+    _restrictions = {'flavor': R('chocolate', 'normal')}
 
 
 class CerealMetadata(DataObject):
     """
     Delicious.
     """
-    _restrictions = {
-        'brand': R('frosted-flakes', 'cheerios')
-        }
+
+    _restrictions = {'brand': R('frosted-flakes', 'cheerios')}
 
 
 dynamic_item = dynamic_restriction_mixin('item', 'item_metadata', milk=MilkMetadata, cereal=CerealMetadata)
@@ -33,11 +32,8 @@ class Breakfast(dynamic_item):
     """
     What is the most important meal of the day?
     """
-    _restrictions = {
-        'item': R('milk', 'cereal'),
-        'item_metadata': R(),
-        'name': R.NULL_STR
-        }
+
+    _restrictions = {'item': R('milk', 'cereal'), 'item_metadata': R(), 'name': R.NULL_STR}
 
     def __init__(self, data=None, **kwargs):
         if data and 'name' not in data:
@@ -54,30 +50,23 @@ class TestDynamicDataObject:
         """
         Test basic instantiation.
         """
-        breakfast = Breakfast({
-            'item': 'milk',
-            'item_metadata': {
-                'flavor': 'chocolate'
-                }
-            })
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
         assert breakfast.item == 'milk'
         assert isinstance(breakfast.item_metadata, MilkMetadata)
         assert breakfast.item_metadata.flavor == 'chocolate'
 
-    @pytest.mark.parametrize('item_metadata', [
-        MilkMetadata({'flavor': 'normal'}),
-        pytest.param(CerealMetadata({'brand': 'cheerios'}), marks=pytest.mark.xfail)
-        ])
+    @pytest.mark.parametrize(
+        'item_metadata',
+        [
+            MilkMetadata({'flavor': 'normal'}),
+            pytest.param(CerealMetadata({'brand': 'cheerios'}), marks=pytest.mark.xfail),
+        ],
+    )
     def test_set(self, item_metadata):
         """
         Test basic setting of a dynamic value.
         """
-        breakfast = Breakfast({
-            'item': 'milk',
-            'item_metadata': {
-                'flavor': 'chocolate'
-                }
-            })
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
         breakfast.item_metadata = item_metadata
         assert breakfast.item_metadata.flavor == 'normal'
 
@@ -85,12 +74,7 @@ class TestDynamicDataObject:
         """
         Test the setting in the child dynamic restriction works fine.
         """
-        breakfast = Breakfast({
-            'item': 'milk',
-            'item_metadata': {
-                'flavor': 'chocolate'
-                }
-            })
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
         assert breakfast.item_metadata.flavor == 'chocolate'
         breakfast.item_metadata.flavor = 'normal'
         assert breakfast.item_metadata.flavor == 'normal'
@@ -112,10 +96,11 @@ class TestInheritance:
             """
             What is the most important meal of the day?
             """
+
             _restrictions = {
                 'item': R('milk', 'cereal'),
                 'item_metadata': R(),
-                }
+            }
 
         assert Breakfast2
 
@@ -130,10 +115,11 @@ class TestInheritance:
             """
             What is the most important meal of the day?
             """
+
             _restrictions = {
                 'item': R('milk', 'cereal'),
                 'item_metadata': R(),
-                }
+            }
 
         assert Breakfast2
 
@@ -148,10 +134,11 @@ class TestInheritance:
             """
             What is the most important meal of the day?
             """
+
             _restrictions = {
                 'item': R('milk', 'cereal'),
                 'item_metadata': R(),
-                }
+            }
 
         assert Breakfast2
 
@@ -166,10 +153,11 @@ class TestInheritance:
             """
             What is the most important meal of the day?
             """
+
             _restrictions = {
                 'item': R('milk'),
                 'item_metadata': R(),
-                }
+            }
 
         assert Breakfast2
 
@@ -179,12 +167,7 @@ class TestInheritance:
         """
         # Validate the starting condition.
         assert Breakfast._restrictions['item_metadata'] == R()
-        milk = Breakfast({
-            'item': 'milk',
-            'item_metadata': MilkMetadata({
-                'flavor': 'chocolate'
-                })
-            })
+        milk = Breakfast({'item': 'milk', 'item_metadata': MilkMetadata({'flavor': 'chocolate'})})
         # Ensure the instance's restrictions were updated correctly.
         assert milk._restrictions['item_metadata'] == MilkMetadata
 
@@ -192,12 +175,7 @@ class TestInheritance:
         assert Breakfast._restrictions['item_metadata'] == R()
 
         # Validate a second instance is created correctly and the restrictions do not clash.
-        milk = Breakfast({
-            'item': 'cereal',
-            'item_metadata': CerealMetadata({
-                'brand': 'cheerios'
-                })
-            })
+        milk = Breakfast({'item': 'cereal', 'item_metadata': CerealMetadata({'brand': 'cheerios'})})
         assert milk._restrictions['item_metadata'] == CerealMetadata
         assert Breakfast._restrictions['item_metadata'] == R()
 
@@ -207,20 +185,10 @@ class TestInheritance:
         """
         # Validate the starting condition.
         assert Breakfast._restrictions['item_metadata'] == R()
-        milk = Breakfast({
-            'item': 'milk',
-            'item_metadata': MilkMetadata({
-                'flavor': 'chocolate'
-                })
-            })
+        milk = Breakfast({'item': 'milk', 'item_metadata': MilkMetadata({'flavor': 'chocolate'})})
         # Ensure the instance's restrictions were updated correctly.
         assert milk._restrictions['item_metadata'] == MilkMetadata
 
-        cereal = Breakfast({
-            'item': 'cereal',
-            'item_metadata': CerealMetadata({
-                'brand': 'frosted-flakes'
-                })
-            })
+        cereal = Breakfast({'item': 'cereal', 'item_metadata': CerealMetadata({'brand': 'frosted-flakes'})})
         assert cereal._restrictions['item_metadata'] == CerealMetadata
         assert milk._restrictions['item_metadata'] == MilkMetadata

--- a/tests/test_managed_restrictions.py
+++ b/tests/test_managed_restrictions.py
@@ -117,16 +117,20 @@ class TestManagedRestrictions:
         except Exception:
             pass
 
-        f_attr = lambda kv: getattr(a, kv[0]) == kv[1]
-        f_item = lambda kv: a[kv[0]] == kv[1]
+        def f_attr(kv):
+            return getattr(a, kv[0]) == kv[1]
+
+        def f_item(kv):
+            return a[kv[0]] == kv[1]
+
         v1 = [city, age, name, state]
         v2 = [valid_city, age, name, state]
         k = ['city', 'age', 'name', 'state']
 
         for _k, _v, _city in [(k, v1, city), (k, v2, valid_city)]:
             a.city = _city
-            assert all([e for e in map(f_attr, zip(_k, _v))]), 'Incorrect attrs'
-            assert all([e for e in map(f_item, zip(_k, _v))]), 'Incorrect items'
+            assert all([e for e in map(f_attr, zip(_k, _v, strict=True))]), 'Incorrect attrs'
+            assert all([e for e in map(f_item, zip(_k, _v, strict=True))]), 'Incorrect items'
 
     @pytest.mark.parametrize('name', ['John Smith'])
     @pytest.mark.parametrize('age', [20])

--- a/tests/test_managed_restrictions.py
+++ b/tests/test_managed_restrictions.py
@@ -2,6 +2,7 @@
 Test managed restrictions.
 :date_created: 2019-03-12
 """
+
 import itertools as it
 
 import pytest
@@ -15,6 +16,7 @@ class Name(ManagedRestrictions):
     """
     Manages name. Standardizes data to title case.
     """
+
     _restriction = R.STR
 
     def manage(self):
@@ -25,6 +27,7 @@ class Age(ManagedRestrictions):
     """
     Manages age. Validates and standardizes data.
     """
+
     _restriction = R.INT
 
     def manage(self):
@@ -34,8 +37,8 @@ class Age(ManagedRestrictions):
 
 city_state = {
     'TX': ['Dallas', 'Houston', 'Austin', 'San Antonio'],
-    'CA': ['Los Angeles', 'San Francisco', 'San Deigo', 'Sacramento']
-    }
+    'CA': ['Los Angeles', 'San Francisco', 'San Deigo', 'Sacramento'],
+}
 
 
 class A(Validator):
@@ -43,15 +46,14 @@ class A(Validator):
         'name': Name(),
         'age': Age(),
         'city': R(*[e for e in it.chain.from_iterable(city_state.values())]),
-        'state': R(*city_state.keys())
-        }
+        'state': R(*city_state.keys()),
+    }
 
     def _validate(self):
         assert self.city in city_state[self.state], 'Mismatched city and state'
 
 
 class TestManagedRestrictions:
-
     @pytest.fixture(params=['john smith'])
     def name(self, request):
         return request.param
@@ -60,9 +62,9 @@ class TestManagedRestrictions:
     def age(self, request):
         return request.param
 
-    @pytest.fixture(params=[('Austin', 'TX'),
-                            pytest.param(('Dallas', 'CA'),
-                                         marks=pytest.mark.xfail(reason='Invalid combination'))])
+    @pytest.fixture(
+        params=[('Austin', 'TX'), pytest.param(('Dallas', 'CA'), marks=pytest.mark.xfail(reason='Invalid combination'))]
+    )
     def city_state(self, request):
         return request.param
 

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -33,15 +33,11 @@ class MgdRest(ManagedRestrictions):
 
 
 class SampleA(DataObject):
-    _restrictions = {
-        'x': R.INT
-        }
+    _restrictions = {'x': R.INT}
 
 
 class SampleB(DataObject):
-    _restrictions = {
-        'x': [1, 2, 3]
-        }
+    _restrictions = {'x': [1, 2, 3]}
 
 
 class SampleC(DataObject):
@@ -53,29 +49,29 @@ class SampleC(DataObject):
         'x': R(SampleB, type(None)),
         'y': SampleA,
         'z': MgdRest(),
-        }
+    }
 
 
 class TestRestriction:
-
     def test_es_restrictions_override(self):
         r = {'type': 'text'}
 
         class SampleD(SampleA):
-            es_restrictions = {
-                'x': r
-                }
+            es_restrictions = {'x': r}
 
         class SampleE(DataObject):
-            _restrictions = {
-                'd': SampleD
-                }
+            _restrictions = {'d': SampleD}
 
         assert SampleE._restrictions['d'].es_restrictions == {'x': r}
 
-    @pytest.mark.parametrize('restriction', [
-        pytest.param([int, float], marks=pytest.mark.xfail(reason='Ambiguous for ES restrictions',
-                                                           raises=RestrictionError))])
+    @pytest.mark.parametrize(
+        'restriction',
+        [
+            pytest.param(
+                [int, float], marks=pytest.mark.xfail(reason='Ambiguous for ES restrictions', raises=RestrictionError)
+            )
+        ],
+    )
     def test_ambiguous_es_restriction(self, restriction):
         x = _ListTypeRestriction(restriction)
         assert x.es_restrictions, 'Failed'
@@ -89,18 +85,22 @@ class TestRestriction:
         except NotImplementedError:
             assert True
 
-    @pytest.mark.parametrize('allowed, default', [(int, 1),
-                                                  (float, 1.1),
-                                                  (bool, True),
-                                                  (date, date.today()),
-                                                  (datetime, datetime.now()),
-                                                  (dict, {'x': 1}),
-                                                  (dict, SampleA(data={'x': 1})),
-                                                  (list, [1, 2]),
-                                                  (set, {1, 2}),
-                                                  (str, 'A'),
-                                                  (tuple, (1, 2))
-                                                  ])
+    @pytest.mark.parametrize(
+        'allowed, default',
+        [
+            (int, 1),
+            (float, 1.1),
+            (bool, True),
+            (date, date.today()),
+            (datetime, datetime.now()),
+            (dict, {'x': 1}),
+            (dict, SampleA(data={'x': 1})),
+            (list, [1, 2]),
+            (set, {1, 2}),
+            (str, 'A'),
+            (tuple, (1, 2)),
+        ],
+    )
     def test_init_and_caching(self, allowed, default):
         instance_1 = R(allowed, default=default)
         assert instance_1
@@ -120,77 +120,97 @@ class TestRestriction:
         assert type(SampleC._restrictions['z']) is _MgdRestRestriction
         assert SampleC._restrictions['z'].es_restrictions is None
 
-    @pytest.mark.parametrize('data', [
-        None,
-        'a',
-        'b',
-        pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'data', [None, 'a', 'b', pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))]
+    )
     def test_null_str_values(self, data):
         SampleC._restrictions['t'](data)
 
-    @pytest.mark.parametrize('data', [
-        'a',
-        'b',
-        pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError)),
-        pytest.param(None, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'data',
+        [
+            'a',
+            'b',
+            pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError)),
+            pytest.param(None, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError)),
+        ],
+    )
     def test_str_values(self, data):
         SampleC._restrictions['u'](data)
 
-    @pytest.mark.parametrize('data', [
-        1, 2, 3, pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'data', [1, 2, 3, pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))]
+    )
     def test_list_values(self, data):
         assert SampleC._restrictions['v'](data)
 
-    @pytest.mark.parametrize('data', [
-        2.0, None, pytest.param('x', marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'data', [2.0, None, pytest.param('x', marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))]
+    )
     def test_list_types(self, data):
         assert SampleC._restrictions['w'](data) == data
 
-    @pytest.mark.parametrize('data', [
-        1, 2, pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=DataObjectError))
-        ])
+    @pytest.mark.parametrize(
+        'data', [1, 2, pytest.param(4, marks=pytest.mark.xfail(reason='Bad data', raises=DataObjectError))]
+    )
     def test_do1(self, data):
         assert SampleC._restrictions['x'](SampleB(data={'x': data}))
 
-    @pytest.mark.parametrize('data', [
-        1, 2, pytest.param('x', marks=pytest.mark.xfail(reason='Bad data', raises=DataObjectError))
-        ])
+    @pytest.mark.parametrize(
+        'data', [1, 2, pytest.param('x', marks=pytest.mark.xfail(reason='Bad data', raises=DataObjectError))]
+    )
     def test_do2(self, data):
         assert SampleC._restrictions['y'](SampleA(data={'x': data}))
 
-    @pytest.mark.parametrize('data', [
-        'good', pytest.param('bad', marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))
-        ])
+    @pytest.mark.parametrize(
+        'data', ['good', pytest.param('bad', marks=pytest.mark.xfail(reason='Bad data', raises=RestrictionError))]
+    )
     def test_mr(self, data):
         assert SampleC._restrictions['z'](data)
 
-    @pytest.mark.parametrize('allowed, default', [
-        pytest.param([SampleA, SampleB], None, marks=pytest.mark.xfail(reason='Two DOs', raises=RestrictionError)),
-        pytest.param([int, 1], None, marks=pytest.mark.xfail(reason='Mixed types', raises=RestrictionError)),
-        pytest.param([SampleA, int, float], None, marks=pytest.mark.xfail(reason='DOs mixed with other types',
-                                                                          raises=RestrictionError)),
-        pytest.param({SampleA, int, float}, None,
-                     marks=pytest.mark.xfail(reason='Syntax error', raises=RestrictionError)),
-        pytest.param([SampleA], int, marks=pytest.mark.xfail(reason='Default value error', raises=RestrictionError)),
-        ])
+    @pytest.mark.parametrize(
+        'allowed, default',
+        [
+            pytest.param([SampleA, SampleB], None, marks=pytest.mark.xfail(reason='Two DOs', raises=RestrictionError)),
+            pytest.param([int, 1], None, marks=pytest.mark.xfail(reason='Mixed types', raises=RestrictionError)),
+            pytest.param(
+                [SampleA, int, float],
+                None,
+                marks=pytest.mark.xfail(reason='DOs mixed with other types', raises=RestrictionError),
+            ),
+            pytest.param(
+                {SampleA, int, float}, None, marks=pytest.mark.xfail(reason='Syntax error', raises=RestrictionError)
+            ),
+            pytest.param(
+                [SampleA], int, marks=pytest.mark.xfail(reason='Default value error', raises=RestrictionError)
+            ),
+        ],
+    )
     def test_restriction_error(self, allowed, default):
         assert R(*allowed, default=default)
 
-    @pytest.mark.parametrize('instance', [
-        pytest.param(SampleC._restrictions['v'],  # ListValue
-                     marks=pytest.mark.xfail(reason='Singleton reuses memory locations')),
-        pytest.param(SampleC._restrictions['w'],  # ListType
-                     marks=pytest.mark.xfail(reason='Singleton reuses memory locations')),
-        pytest.param(SampleC._restrictions['x'],  # NullableDO
-                     marks=pytest.mark.xfail(reason='Singleton reuses memory locations')),
-        pytest.param(SampleC._restrictions['y'],  # DO
-                     marks=pytest.mark.xfail(reason='Singleton reuses memory locations')),
-        SampleC._restrictions['z'],  # MgdRestr is not Singleton
-        ])
+    @pytest.mark.parametrize(
+        'instance',
+        [
+            pytest.param(
+                SampleC._restrictions['v'],  # ListValue
+                marks=pytest.mark.xfail(reason='Singleton reuses memory locations'),
+            ),
+            pytest.param(
+                SampleC._restrictions['w'],  # ListType
+                marks=pytest.mark.xfail(reason='Singleton reuses memory locations'),
+            ),
+            pytest.param(
+                SampleC._restrictions['x'],  # NullableDO
+                marks=pytest.mark.xfail(reason='Singleton reuses memory locations'),
+            ),
+            pytest.param(
+                SampleC._restrictions['y'],  # DO
+                marks=pytest.mark.xfail(reason='Singleton reuses memory locations'),
+            ),
+            SampleC._restrictions['z'],  # MgdRestr is not Singleton
+        ],
+    )
     def test_deep_copy(self, instance):
         instance_copy = deepcopy(instance)
         assert instance == instance_copy
@@ -199,11 +219,7 @@ class TestRestriction:
 
     def test_singleton(self):
         class Singletons(DataObject):
-            _restrictions = {
-                'v': R(1, 2, 3),
-                'x': R(SampleB, type(None)),
-                'y': SampleA
-                }
+            _restrictions = {'v': R(1, 2, 3), 'x': R(SampleB, type(None)), 'y': SampleA}
 
         for k in Singletons._restrictions:
             assert id(Singletons._restrictions[k]) == id(SampleC._restrictions[k])

--- a/tests/test_utils/test_encoder.py
+++ b/tests/test_utils/test_encoder.py
@@ -5,7 +5,6 @@ from do_py.utils.json_encoder import MyJSONEncoder
 
 
 class TestMyJSONEncoder:
-
     def test(self):
         today_datetime = datetime.today()
         today_date = today_datetime.date()

--- a/tests/test_utils/test_properties.py
+++ b/tests/test_utils/test_properties.py
@@ -1,6 +1,7 @@
 """
 Test the property decorators and related utils.
 """
+
 import time
 
 from do_py.utils.properties import (
@@ -17,6 +18,7 @@ class ATest:
     """
     Dummy class for testing `is_classmethod` and `is_property`.
     """
+
     CLS_VALUE = 'hello world'
 
     @classproperty


### PR DESCRIPTION
## Phase 6 of the repo refresh — code quality

Clears the remaining ruff permanent-ignore list where safe, formalizes the public API via `__all__`, adds PEP 561 `py.typed` marker, and applies `ruff format` across the codebase.

**Net: +458 / -524 lines** (of which ~1800 lines are mechanical formatting churn in commit 7).

### Commits (7)

| SHA | Summary |
|---|---|
| `9f6a824` | `fix: replace mutable default args with None sentinel in __deepcopy__` |
| `8fbf0bb` | `style: add exception chaining (raise X from e) to translated exceptions` |
| `d1d374f` | `style: use def instead of lambda-assignment and strict=True on zip()` |
| `1f3ad8b` | `refactor: add __all__ to __init__.py re-export modules` |
| `17ac5ad` | `build: tighten ruff ignores after Phase 6 code fixes` |
| `e43de1e` | `feat: add PEP 561 py.typed marker` |
| `63e7802` | `style: run `ruff format` on all Python files` |

### Reviewing tips

Commits 1-6 are small and logical. **Commit 7** (`ruff format`) is a 30-file whitespace-only pass and should be reviewed at a glance or skipped.

### Ruff ignore list shrinkage

| Rule | Before | After | Why |
|---|---|---|---|
| B006 | ignored | **fixed** | 2 `__deepcopy__(memodict={})` → `None` sentinel pattern |
| B904 | ignored | **fixed** | 6 translated-exception sites got `from e` chaining |
| B905 | ignored | **fixed** | 2 `zip()` calls in tests got `strict=True` |
| E731 | ignored | **fixed** | 2 `f = lambda ...` → `def f(...)` |
| E501 | ignored | ignored | line-length is advisory |
| E721 | ignored | ignored | intentional strict `type(x) is T` checks |
| B008 | ignored | ignored | false-positive heavy for dataclass-like APIs |
| UP008 | ignored | ignored | unsafe under `@ABCRestrictions.require` class-rebuild pattern (see Phase 5) |
| UP031 | ignored | ignored | pervasive printf-style error-message templates; semantic change deferred |

### Public API now explicit

`__all__` added to three `__init__.py` files:

| Module | Public exports |
|---|---|
| `do_py` | `DataObject`, `R` |
| `do_py.exceptions` | `DataObjectError`, `RestrictionError` |
| `do_py.utils` | `MyJSONEncoder`, `classproperty`, `cached_property`, `is_cached_property`, `is_classmethod`, `is_property` |

F401 per-file-ignores for these three removed from ruff config.

### PEP 561 `py.typed`

- Empty marker file at `do_py/py.typed`
- `Typing :: Typed` trove classifier added
- Hatchling ships the marker in both sdist and wheel (verified)

No annotations are yet added — effect today is that type checkers will see do-py as `Any`-typed, same as before, but the marker declares intent and unlocks incremental annotation without a flag day.

**Why not a full annotation pass?** DataObject is a `dict` subclass + custom metaclass + class-rebuild-via-decorator hybrid, and `R`'s classproperty-heavy surface needs `typing.overload` to express cleanly. Safe incremental annotation needs more care than a solo overnight pass can deliver. Future work.

### `ruff format` + CI enforcement

- `quote-style = "single"` configured to preserve the codebase's existing convention (double-quote default would've been a noisy no-op change across hundreds of strings)
- 28 of 34 files reformatted: indentation normalization, short-dict-literal collapse, blank-line-after-class-docstring, long-call wrapping
- CI now runs `ruff format --check` on every PR

### Verification (local, Python 3.12)

- `uv run ruff check do_py tests` → ✅
- `uv run ruff format --check do_py tests` → ✅
- `uv run pytest --cov` → ✅ **172 passed, 76 xfailed, 97% coverage** (unchanged)
- `uv build` → ✅ sdist + wheel ship `do_py/py.typed`

### Phase 7 preview

CHANGELOG, version bump, release prep. Stacked on this branch — will open as a separate PR with this branch as base.
