### PR TITLE
Phase 7: 1.0.0 release prep (CHANGELOG + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - Unreleased
+
+First stable release. The 1.0 milestone reflects a comprehensive repo
+modernization; the public API (`DataObject`, `R`, the exception classes)
+is unchanged from 0.4.1 in behavior, but several foundational
+environmental changes make this a breaking release.
+
+### Breaking
+
+- **Dropped Python 2 support.** The `future` and `past` compatibility
+  shims are gone from the codebase. do-py is now a pure Python 3
+  library.
+- **Minimum Python version raised to 3.10.** Tested against 3.10, 3.11,
+  3.12, and 3.13. Python 2.7 and 3.7–3.9 are no longer supported.
+- **Removed `future>=0.18` runtime dependency.** do-py now has **zero**
+  runtime dependencies.
+- **Schema-value output cosmetic change.** `_ListTypeRestriction.schema_value`
+  no longer hides the synthetic `newstr`/`newint`/`long` type names
+  (those types can't appear anymore). In practice output is identical
+  for all real-world restrictions.
+
+### Added
+
+- [PEP 561](https://peps.python.org/pep-0561/) `py.typed` marker so
+  type checkers recognize the package (no annotations yet; surface is
+  `Any`-typed).
+- `__all__` declarations on `do_py/__init__.py`,
+  `do_py/exceptions/__init__.py`, and `do_py/utils/__init__.py` to
+  formalize the public API.
+- `CHANGELOG.md` (this file).
+
+### Changed
+
+- **Build backend:** `setuptools` + `setup.py` + `MANIFEST.in` →
+  [hatchling](https://hatch.pypa.io/latest/) via `pyproject.toml`
+  ([PEP 621](https://peps.python.org/pep-0621/) metadata).
+- **Dependency/env management:** `pipenv` + `Pipfile` → [uv](https://docs.astral.sh/uv/)
+  + `pyproject.toml [dependency-groups]` ([PEP 735](https://peps.python.org/pep-0735/)).
+  CI install time is roughly **3× faster**.
+- **Developer tooling:** `yarn` + `package.json` + `release-it` (Node.js
+  toolchain) → [mise](https://mise.jdx.dev) with tasks for install /
+  test / lint / format / build / publish / clean.
+- **Linter:** `pylint` (17KB `.pylintrc`, unused in CI) →
+  [ruff](https://docs.astral.sh/ruff/) configured inline in `pyproject.toml`.
+  Ruff also runs as a formatter (`quote-style = "single"` to preserve
+  the codebase's existing convention).
+- **CI:** GitHub Actions versions bumped to latest (checkout@v4,
+  setup-uv@v5, codecov-action@v4). Matrix is now 3.10–3.13 with
+  `fail-fast: false`.
+
+### Fixed
+
+- `DataObject.__deepcopy__` and `AbstractRestriction.__deepcopy__`
+  had `memodict={}` as a default argument — a classic Python
+  mutable-default bug. Now use the idiomatic `memodict=None` sentinel.
+- Six exception-translation sites now use `raise X from e` so
+  tracebacks preserve the original cause.
+- Two `zip()` calls in the test suite now pass `strict=True` to catch
+  accidental iterable-length mismatches.
+- Broken code example in `README.md`: `Contact._restrictions` was a
+  set literal (`{'phone_number'}`) rather than a dict, and the
+  `VideoGame({...})` instantiation used keys that didn't exist on the
+  class. Rewrote to a valid nested-DataObject example.
+
+### Removed
+
+- `setup.py`, `MANIFEST.in`, `Pipfile`, `Pipfile.lock`.
+- `package.json`, `yarn.lock`, `node_modules/`, `.release-it.js`.
+- `.pylintrc`, `tests/.coveragerc`.
+- Zero-byte leftover `test.json` at repo root.
+- `twine` pinned dev dependency (release is now `uv publish`).
+- `from builtins import object`, `from future.*`, `from past.*`,
+  `with_metaclass(...)`, `IS_PY3`, `newint`/`newstr`/`newlist`,
+  `unicode`, `long` — all Python 2 compat shims.
+
+### Infrastructure
+
+- Dropped **~2000 lines** of Node.js dependency metadata from the
+  repo (`yarn.lock`, 42 Dependabot vulnerabilities resolved).
+- `_config.yml` and other incidental files preserved.
+
+### Migration guide
+
+For end users upgrading from 0.4.1:
+
+- **If you're on Python 3.10+:** no code changes needed. `pip install
+  -U do-py`.
+- **If you're on Python 2.7 / 3.7 / 3.8 / 3.9:** pin to `do-py==0.4.1`
+  or upgrade your interpreter. 0.4.1 remains available on PyPI for
+  legacy workloads.
+- **If you import Py2-compat internals** (`do_py.common.IS_PY3`,
+  `newint`, `newstr` via `do_py.data_object.restriction`): these
+  never were public API and are gone. Use native `int` / `str`.
+
+For contributors:
+
+- **Environment:** `mise install && mise run install` (or, without
+  mise, `uv sync --group dev`).
+- **Tests:** `mise run test` (or `uv run pytest ./tests/`).
+- **Lint:** `mise run lint` (or `uv run ruff check do_py tests`).
+- **Format:** `mise run format` (or `uv run ruff format do_py tests`).
+
+## [0.4.1] - 2021-11-28
+
+Previous release under the old `package.json`-tracked versioning.
+See git history for details.
+
+[1.0.0]: https://github.com/do-py-together/do-py/compare/v0.4.1...v1.0.0
+[0.4.1]: https://github.com/do-py-together/do-py/releases/tag/v0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "do-py"
-version = "0.4.1"
+version = "1.0.0"
 description = "Data validation and standardization library wrapping Python dictionaries."
 readme = "README.md"
 license = { text = "MIT" }
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = []
 keywords = ["development", "OO"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ toml = [
 
 [[package]]
 name = "do-py"
-version = "0.4.1"
+version = "1.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Phase 7 of the repo refresh — 1.0.0 release prep

🎉 **Stacked on top of #60 (Phase 6).** When Phase 6 merges, GitHub will auto-retarget this PR's base to `master` and the diff will shrink to just this release commit.

Wraps the repo-refresh series with a version bump and a comprehensive `CHANGELOG.md`. No code changes — pure release prep.

### Single commit

`6f41226` — `release: bump version to 1.0.0 and add CHANGELOG`

### Changes

- `pyproject.toml [project].version`: `0.4.1` → `1.0.0`
- `pyproject.toml` classifier: `Development Status :: 4 - Beta` → `Development Status :: 5 - Production/Stable`
- `uv.lock` regenerated against 1.0.0
- **New file** `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) format, documenting the full 0.4.1 → 1.0.0 story with sections for Breaking / Added / Changed / Fixed / Removed / Infrastructure, plus migration guidance for both end users and contributors.

### Why 1.0.0

The refresh series (#54–#60) made the following breaking changes:

- Dropped Python 2 support
- Raised min Python to 3.10
- Removed `future>=0.18` runtime dependency (do-py is now **zero-dep**)
- `_ListTypeRestriction.schema_value` cosmetic output change (no effect on real restrictions)

Public API (`DataObject`, `R`, exception classes) is behaviorally unchanged for users already on Python 3.9+. The major version bump marks the coherent modernized baseline, not an API rewrite.

### Explicitly NOT done in this PR

- **No `uv publish`.** The PR does not push to PyPI. After merge, cut a `v1.0.0` git tag and run `mise run publish` (or `uv publish`) manually with your PyPI credentials.
- **No GitHub Release.** Same reason — that's a manual human step you may want to customize.

### Verification

- `uv lock` clean
- `uv build` produces `do_py-1.0.0.tar.gz` and `do_py-1.0.0-py3-none-any.whl`
- CI will re-run Phase 6's full test + lint + format matrix against the version bump

### Merge order

1. Merge **#60** (Phase 6) first
2. Come back here — GitHub will have retargeted base to `master`
3. Merge **#61** (this PR)
4. Tag `v1.0.0` on master
5. `mise run publish` (or `uv publish`) to push to PyPI

---

### Refresh series recap (#54 → #61)

| PR | Phase | Summary |
|---|---|---|
| #54 | 0 | Repo cleanup (.gitignore, README) |
| #55 | 1 | CI baseline (modernize actions, drop Py2.7) |
| #56 | 2 | Drop Python 2 + `future` dependency |
| #57 | 3 | Expand matrix to Python 3.10–3.13 |
| #58 | 4 | Packaging migration (pyproject.toml + mise + uv) |
| #59 | 5 | Replace pylint with ruff |
| #60 | 6 | Code quality (ruff fixes, `__all__`, `py.typed`, format) |
| #61 | 7 | **1.0.0 release prep** ← this PR |

**Aggregate diff across the series:** roughly **+900 / -4500 lines**. Repo is now pure-Python, zero runtime dependencies, modern tooling, CI roughly 3× faster than the pipenv baseline. 🥂
