### PR TITLE
ci: add PyPI trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+# Publishes do-py to PyPI via OIDC trusted publishing.
+#
+# Trigger: a GitHub Release is published. This workflow checks out the
+# tag the release points at, builds sdist + wheel with uv, and uploads
+# to PyPI using an OIDC-issued short-lived token \u2014 no long-lived secrets
+# are stored in the repo.
+#
+# One-time PyPI setup required before this can succeed:
+#   https://pypi.org/manage/project/do-py/settings/publishing/
+# Add a pending publisher with:
+#   Owner           : do-py-together
+#   Repository name : do-py
+#   Workflow name   : release.yml
+#   Environment name: pypi
+#
+# Docs: https://docs.pypi.org/trusted-publishers/
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    # The "pypi" environment can be configured in repo settings to
+    # require manual approval before publishing, scope the id-token
+    # permission, etc. https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment
+    environment:
+      name: pypi
+      url: https://pypi.org/p/do-py
+    permissions:
+      # Required for OIDC trusted publishing. No other permissions needed.
+      id-token: write
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: '3.12'
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pyver=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "Git tag version:     $tag"
+          echo "pyproject.toml ver:  $pyver"
+          if [ "$tag" != "$pyver" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match pyproject.toml version '$pyver'"
+            exit 1
+          fi
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Inspect built artifacts
+        run: ls -la dist/
+      - name: Publish to PyPI (trusted publishing)
+        run: uv publish --trusted-publishing always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,38 @@ mise run format      # or: uv run ruff format do_py tests
 Ruff config lives in `[tool.ruff]` in `pyproject.toml`. CI runs
 `ruff check` on every PR.
 
-### Building and publishing
+### Building
 
 ```bash
 mise run build       # uv build  -> sdist + wheel in ./dist
-mise run publish     # uv publish
 ```
+
+### Releasing
+
+Releases are published to PyPI automatically via GitHub Actions using
+[OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) —
+no API tokens are stored in the repo.
+
+To cut a release:
+
+1. Bump `[project].version` in `pyproject.toml` on a PR, get it merged
+   to `master`.
+2. Update `CHANGELOG.md` with the release date and notes on the same
+   PR (or a follow-up).
+3. On GitHub, go to **Releases → Draft a new release**.
+4. Create a new tag `vX.Y.Z` (matching the version in `pyproject.toml`)
+   targeting `master`.
+5. Fill in release notes (use the CHANGELOG section as a starting
+   point) and click **Publish release**.
+6. The `.github/workflows/release.yml` workflow runs automatically,
+   builds sdist + wheel with `uv build`, and uploads to PyPI.
+
+The release workflow verifies that the git tag matches
+`pyproject.toml`'s version before publishing, so a mismatch will fail
+fast instead of shipping wrong metadata.
+
+If you need to publish locally (e.g. to TestPyPI) you can still run
+`mise run publish` with a PyPI API token in `UV_PUBLISH_TOKEN`.
 
 ## Developer Notes
 


### PR DESCRIPTION
## Trusted publishing release workflow

Wires up PyPI [trusted publishing](https://docs.pypi.org/trusted-publishers/) via GitHub Actions so we can cut releases without any long-lived PyPI tokens on contributor machines or in repo secrets.

### Context

After the v1.0.0 tag was pushed, the only remaining step is the PyPI upload. The existing `~/.pypirc`-based path uses 2021-era username/password credentials that PyPI no longer accepts. Rather than minting a personal API token for a one-off upload, this PR sets up the modern pattern.

### What this PR adds

**`.github/workflows/release.yml`** — triggered by `release: { types: [published] }`:

1. Check out the tag the GitHub Release points at
2. Set up uv + Python 3.12
3. **Verify `git tag` matches `pyproject.toml` version** — fails fast on drift
4. `uv build` → sdist + wheel
5. `uv publish --trusted-publishing always` — OIDC token issued by GitHub at workflow runtime

**`CONTRIBUTING.md`** — new "Releasing" section documenting the full flow.

### Security properties

- **No long-lived PyPI tokens anywhere** — not in the repo, not in secrets, not on laptops
- **OIDC token is short-lived and scoped** — issued per-workflow-run, PyPI verifies the exact repo/workflow/environment
- **`id-token: write`** is the only elevated permission — minimal blast radius
- **GitHub Environment `pypi`** — you can add required reviewers or branch-protection rules in repo Settings → Environments → pypi if you want a human-in-the-loop before upload
- **Tag/version drift check** — prevents accidentally publishing `pyproject.toml = 1.0.1` under tag `v1.0.0`

### Required one-time setup on PyPI (before first release)

Since the `do-py` project already exists on PyPI (v0.4.1 is published), this configuration goes on the **existing project's settings page**, not as a "pending publisher":

1. Go to https://pypi.org/manage/project/do-py/settings/publishing/
2. Under "Add a new publisher", pick **GitHub**, and fill in:
   - **Owner**: `do-py-together`
   - **Repository name**: `do-py`
   - **Workflow name**: `release.yml`
   - **Environment name**: `pypi`
3. Click **Add**

### After this PR is merged — publishing v1.0.0

1. On GitHub: **Releases → Draft a new release**
2. Choose the existing tag `v1.0.0`
3. Set title: `v1.0.0 — First stable release`
4. Fill in release notes (copy the `## [1.0.0]` section from `CHANGELOG.md` is a good start)
5. Click **Publish release**
6. The `release.yml` workflow will fire automatically and publish `do-py 1.0.0` to PyPI within ~30 seconds
7. Verify at https://pypi.org/project/do-py/

### Future releases

Same flow: bump `pyproject.toml`, update `CHANGELOG.md`, merge, then Draft Release on GitHub with the new tag. No local `uv publish` needed.

### Verification that couldn't happen locally

- **Actual OIDC flow** — only works inside GitHub Actions; we'll see it succeed on the first real release run
- **PyPI trusted publisher handshake** — dependent on the PyPI-side config you'll add

If the first publish attempt fails, the workflow output will make it obvious whether it's (a) missing PyPI config, (b) tag/version mismatch, or (c) OIDC / environment misconfiguration, and we can iterate.
