### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,18 @@
 name: release
 
 on:
+  # Primary trigger: a GitHub Release is published. The UI flow
+  # (Releases -> Draft a new release -> Publish) fires this.
   release:
     types: [published]
+  # Escape hatch for when the release event doesn't fire for some reason,
+  # or for re-publishing after an aborted run. Takes a tag to build from.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build and publish (e.g. v1.0.0)'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -34,8 +44,20 @@ jobs:
       # Required for OIDC trusted publishing. No other permissions needed.
       id-token: write
     steps:
+      - name: Resolve target tag
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+          echo "Target tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
       - name: Check out the tagged commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -43,12 +65,13 @@ jobs:
           python-version: '3.12'
       - name: Verify tag matches pyproject.toml version
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          tag="${{ steps.resolve.outputs.tag }}"
+          tag_ver="${tag#v}"
           pyver=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          echo "Git tag version:     $tag"
+          echo "Git tag version:     $tag_ver"
           echo "pyproject.toml ver:  $pyver"
-          if [ "$tag" != "$pyver" ]; then
-            echo "::error::Tag '$GITHUB_REF_NAME' does not match pyproject.toml version '$pyver'"
+          if [ "$tag_ver" != "$pyver" ]; then
+            echo "::error::Tag '$tag' does not match pyproject.toml version '$pyver'"
             exit 1
           fi
       - name: Build sdist and wheel


### PR DESCRIPTION
## Add `workflow_dispatch` trigger to release workflow

### Why

The v1.0.0 release was published via the GitHub Release UI but the `release.yml` workflow never fired. Diagnostics:

```
$ gh api /repos/do-py-together/do-py/actions/workflows/release.yml/runs --jq '.total_count'
0
```

Zero runs ever triggered for this workflow. Root cause unclear — possibly a known GitHub Actions quirk where releases created as drafts (13:24:57 UTC) before the workflow existed on master (merged 14:19:50 UTC) and later published (14:24:12 UTC) don't re-evaluate the event trigger against the current default-branch state.

### What this PR adds

**`.github/workflows/release.yml`** — two changes:

1. **`workflow_dispatch` trigger with a `tag` input**
   Provides an escape hatch. Manual re-runs from the Actions UI, or via CLI:

   ```bash
   gh workflow run release.yml -f tag=v1.0.0
   ```

2. **Explicit `ref` on `actions/checkout`**
   The workflow now resolves the target tag from either `github.event.release.tag_name` (release event) or `inputs.tag` (dispatch event) and checks out exactly that tag. Previously relied on the implicit `github.sha`, which is less predictable across trigger types.

### After merging

To ship v1.0.0 to PyPI, you have two options:

**Option A — manual dispatch (fastest)**
```bash
gh workflow run release.yml -f tag=v1.0.0 --ref master
```
Or in the browser: Actions → release → "Run workflow" → enter `v1.0.0`.

**Option B — delete + recreate the GitHub Release**
If you prefer the release-event path works end-to-end before trusting it:
```bash
gh release delete v1.0.0 --yes                  # keeps the git tag
gh release create v1.0.0 --title "v1.0.0 ..." --notes-file ...
```
This should fire the `release: published` event correctly now that the workflow file was on master the whole time.

I'd suggest **Option A** — it's the one-off publish, and workflow_dispatch is a good tool to keep in the kit anyway for future troubleshooting.

### For future releases

The release-event path should work normally (when the workflow file has already been on master for a while before the release is published). The dispatch trigger is belt-and-suspenders for edge cases.
