### PR TITLE
test: replace try/except anti-patterns with pytest.raises

### DIFF
--- a/tests/data.py
+++ b/tests/data.py
@@ -21,7 +21,3 @@ data = [
 short_data = [data[0]]
 keys = ['id', 'name', 'status', pytest.param('random', marks=pytest.mark.xfail)]
 key_values = [('id', 1), ('name', 'yay'), ('status', 1), pytest.param('random', 'random', marks=pytest.mark.xfail)]
-
-
-class MyTestException(Exception):
-    pass

--- a/tests/test_abc_restrictions.py
+++ b/tests/test_abc_restrictions.py
@@ -7,9 +7,21 @@ import pytest
 from do_py.abc import ABCRestrictionMeta, ABCRestrictions
 from do_py.abc.constants import ConstABCR
 
-from .data import MyTestException
+
+@pytest.fixture()
+def _abc_cleanup():
+    """
+    Snapshot and restore ABCRestrictionMeta global state so that test-created
+    classes never leak into other tests.
+    """
+    original_classes = set(ABCRestrictionMeta._abc_classes)
+    original_uniques = {k: list(v) for k, v in ABCRestrictionMeta._unique_attrs.items()}
+    yield
+    ABCRestrictionMeta._abc_classes = original_classes
+    ABCRestrictionMeta._unique_attrs = {k: list(v) for k, v in original_uniques.items()}
 
 
+@pytest.mark.usefixtures('_abc_cleanup')
 class TestABCRestrictions:
     @pytest.mark.parametrize('def_new', [False, True])
     def test_require_decorator(self, def_new):
@@ -19,8 +31,6 @@ class TestABCRestrictions:
         class MyMeta(type):
             pass
 
-        teardown_classes = []  # Append to this everytime we ".require" decorate a class
-
         namespace = {'__module__': __name__}
         if def_new:
             namespace['__new__'] = classmethod(__new__)
@@ -28,81 +38,46 @@ class TestABCRestrictions:
         namespace[ConstABCR.is_abstract] = True
 
         RestrictedOk = ABCRestrictions.require('x')(type('RestrictedOk', tuple(), namespace))
-        teardown_classes.append(RestrictedOk)
-        assert RestrictedOk
+        assert RestrictedOk, 'ABCRestrictions.require failed to return a class'
         assert type(RestrictedOk) is ABCRestrictionMeta, 'Failed to apply ABCRestrictionMeta'
         assert RestrictedOk in ABCRestrictionMeta.abc_classes
-        try:
+
+        # Leaf without required attribute must fail
+        with pytest.raises(AssertionError):
             type('InvalidSubOk', (RestrictedOk,), {})
-            raise Exception('Compile time validation failed!')
-        except AssertionError:
-            assert True
+
         SubOk = type('SubOk', (RestrictedOk,), {'x': 1, '__module__': __name__})
-        assert SubOk
+        assert SubOk, 'Leaf class creation failed'
         assert SubOk.x == 1
 
         MiddleLayerOk = type('MiddleLayerOk', (RestrictedOk,), {ConstABCR.is_abstract: True, '__module__': __name__})
-        assert MiddleLayerOk
+        assert MiddleLayerOk, 'Node class creation failed'
         assert 'x' not in MiddleLayerOk.__dict__
 
-        # Additional and unique requirements
-        try:
+        # Re-requiring on a reserved namespace must fail
+        with pytest.raises(AssertionError):
             ABCRestrictions.require('x')(MiddleLayerOk)
-            raise MyTestException('Able to re-require a reserved namespace!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
         UniqueOk = ABCRestrictions.require('y', unique=['y'])(MiddleLayerOk)
-        teardown_classes.append(UniqueOk)
         UniqueSubOk = type('AdditionalSubOk', (UniqueOk,), {'x': 1, 'y': 2, '__module__': __name__})
-        teardown_classes.append(UniqueSubOk)
-        assert UniqueSubOk
+        assert UniqueSubOk, 'Leaf with additional unique attr failed'
         assert UniqueSubOk.x == 1
         assert UniqueSubOk.y == 2
 
-        try:
+        # Duplicate unique value must fail
+        with pytest.raises(AssertionError):
             type('AdditionalSubOk2', (UniqueOk,), {'x': 1, 'y': 2, '__module__': __name__})
-            raise MyTestException('Value check on unique attribute failed!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
-        # Reserved unique attribute namespace
-        try:
+        # Reserved unique attribute namespace must fail
+        with pytest.raises(AssertionError):
             ABCRestrictions.require('y', unique=['y'])(MiddleLayerOk)
-            raise MyTestException('Able to require uniqueness on a reserved namespace!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
-        # Metaclass ambiguity
-        try:
+        # Metaclass ambiguity must fail
+        with pytest.raises(Exception, match='[Mm]etaclass'):
             _cls = MyMeta('AdditionSubBad', (), namespace)
             ABCRestrictions.require('x')(_cls)
-            raise MyTestException('Metaclass ambiguity should have thrown error.')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
-
-        # Teardown  # TODO: Support teardown on test failure too
-        for cls in teardown_classes:
-            if cls in ABCRestrictionMeta._abc_classes:
-                ABCRestrictionMeta._abc_classes.remove(cls)
-            for a in ABCRestrictionMeta._unique_attrs:
-                if cls in ABCRestrictionMeta._unique_attrs[a]:
-                    ABCRestrictionMeta._unique_attrs[a].remove(cls)
 
     @pytest.mark.parametrize('parent_class', sorted(ABCRestrictionMeta.abc_classes.keys(), key=lambda x: x.__name__))
     def test_not_instantiable(self, parent_class):
-        try:
+        with pytest.raises(NotImplementedError):
             parent_class()
-            assert False
-        except NotImplementedError:
-            assert True
-        except Exception:
-            assert False

--- a/tests/test_data_object/test_data_object.py
+++ b/tests/test_data_object/test_data_object.py
@@ -11,15 +11,13 @@ from do_py import DataObject
 from do_py.common import R
 from do_py.exceptions import DataObjectError, RestrictionError
 
-from ..data import A, MyTestException, data, keys, short_data
+from ..data import A, data, keys, short_data
 
 
 def our_hasattr(instance, name):
     """
-
-    :param instance:
-    :param name:
-    :return:
+    Check if *name* lives in the instance's own ``__dict__`` (not in the
+    class or its MRO).
     """
     return name in instance.__dict__
 
@@ -28,28 +26,23 @@ class TestDataObject:
     @pytest.mark.parametrize('id, name, status', data)
     def test_init(self, id, name, status):
         a = A.create(id=id, name=name, status=status)
-        assert a
+        assert a, 'A.create returned a falsy value'
         assert a.id == id
         assert a.name == name
         assert a.status == status
         assert a['id'] == id
         assert a['name'] == name
         assert a['status'] == status
-        assert a(data=a)
+        assert a(data=a), '__call__ re-init failed'
 
     def test_class_namespace(self):
-        try:
+        with pytest.raises(AttributeError):
 
             class B(DataObject):
                 _restrictions = {'x': R.INT.with_default(1)}
                 x = None
 
             B(data={'x': 1})
-            raise Exception('Failed to protect namespace clash between _restrictions and cls.x!')
-        except AttributeError:
-            assert True
-        except Exception as e:
-            assert False, str(e)
 
     @pytest.mark.parametrize(
         'deep',
@@ -114,7 +107,7 @@ class TestDataObject:
         if not d:
             data_ = None
         b = B(data=data_, strict=strict)
-        assert b
+        assert b, 'B() returned a falsy value'
 
     def test_nested_restrictions(self):
         class B(DataObject):
@@ -135,21 +128,13 @@ class TestDataObject:
         assert type(c.b) is B
         assert c.b.x
 
-        # Test nested validation
-        try:
+        # Test nested validation — invalid value for a restricted key
+        with pytest.raises((RestrictionError, DataObjectError)):
             c.b.x = 'invalid'
-            raise MyTestException('Invalid value assigned to c.b.x!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
-        try:
+
+        # Test nested validation — invalid data dict
+        with pytest.raises(DataObjectError):
             c.b = {'invalid': 'values'}
-            raise MyTestException('Invalid data dict assigned to c.b!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
         # Test default value behavior
         c_default = C(strict=False)
@@ -158,7 +143,7 @@ class TestDataObject:
         assert type(c_default.a) is A
         assert type(c_default.b) is B
         for k, v in c_default.a.items():
-            assert v is None, [(k, v) for k, v in c_default.a.items()]
+            assert v is None, 'Expected None for key %r, got %r' % (k, v)
 
     @pytest.mark.parametrize('restrictions', [pytest.param(R(A, type(None)), id='([A, type(None)], None)'), A])
     def test_supported_nested_restrictions_format(self, restrictions):
@@ -189,30 +174,20 @@ class TestDataObject:
         assert b
 
     def test_missing_restrictions(self):
-        try:
+        with pytest.raises(AssertionError):
 
             class B(DataObject):
                 pass
 
             B()
-            raise MyTestException('Error should have thrown.')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
     def test_nesting_dict_restrictions(self):
-        try:
+        with pytest.raises(DataObjectError):
 
             class B(DataObject):
                 _restrictions = {'a': {'x': [], 'y': []}}
 
             B(data={'a': {'x': 1, 'y': 2}})
-            raise MyTestException('Error should have thrown.')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
     @pytest.mark.parametrize('id, name, status', short_data)
     def test_setitem(self, id, name, status):
@@ -228,26 +203,18 @@ class TestDataObject:
         assert a['id'] == newer_id
         assert a.id == newer_id
 
-        try:
+        # Assigning to an unrestricted key via item access must fail
+        with pytest.raises(KeyError):
             a['invalid'] = 'something'
-            raise MyTestException('Able to assign a value to an unrestricted key!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
         # Attribute space can be freeform, but will not become part of restricted data schema
         a.invalid = 'something'
         assert our_hasattr(a, 'invalid'), 'Attribute not found'
         assert 'invalid' not in a
         assert a.invalid == 'something'
-        try:
+
+        with pytest.raises(KeyError):
             _ = a['invalid']
-            raise MyTestException('Able to pull out value set in attribute namespace from keyspace!')
-        except MyTestException as e:
-            assert False, str(e)
-        except Exception:
-            assert True
 
     @pytest.mark.parametrize('id, name, status', short_data)
     def test_get(self, id, name, status):
@@ -255,16 +222,12 @@ class TestDataObject:
         assert a.get('id') == a.id == id
         assert a.get('name') == a.name == name
         assert a.get('status') == a.status == status
-        try:
+
+        with pytest.raises(KeyError):
             _ = a['nope']
-            assert False
-        except KeyError:
-            assert True
-        try:
+
+        with pytest.raises(AttributeError):
             _ = a.nope
-            assert False
-        except AttributeError:
-            assert True
 
     @pytest.mark.parametrize('id, name, status', short_data)
     @pytest.mark.parametrize('key', keys)
@@ -275,35 +238,21 @@ class TestDataObject:
     @pytest.mark.parametrize('id, name, status', short_data)
     def test_clear_pop(self, id, name, status):
         a = A.create(id=id, name=name, status=status)
-        try:
+
+        with pytest.raises(TypeError):
             a.clear()
-            assert False
-        except TypeError:
-            assert True
 
-        try:
+        with pytest.raises(TypeError):
             a.pop('id')
-            assert False
-        except TypeError:
-            assert True
 
-        try:
+        with pytest.raises(TypeError):
             a.popitem()
-            assert False
-        except TypeError:
-            assert True
 
-        try:
+        with pytest.raises(TypeError):
             del a['id']
-            assert False
-        except TypeError:
-            assert True
 
-        try:
+        with pytest.raises(TypeError):
             a.update({'id': 1})
-            assert False
-        except TypeError:
-            assert True
 
     @pytest.mark.parametrize('complex', [pytest.param(True, marks=pytest.mark.xfail), False])
     def test_str_repr(self, complex):
@@ -317,9 +266,9 @@ class TestDataObject:
 
         a = B(data={'datetime': datetime.now(), 'date': date.today(), 'default': MyObj if complex else 'hello world'})
         # __repr__ returns JSON
-        assert json.loads('%r' % a)
+        assert json.loads('%r' % a), '__repr__ did not produce valid JSON'
         # __str__ returns string
-        assert '%s' % a
+        assert '%s' % a, '__str__ produced empty string'
 
     @pytest.mark.parametrize(
         'd, strict',
@@ -349,9 +298,7 @@ class TestDataObject:
     @pytest.mark.parametrize('id, name, status', short_data)
     def test_attr_restr_mutually_exclusive(self, id, name, status):
         """
-        Restriction keys should not be present in attr space. Not key attributes should live in attribute space.
-        :return:
-        :rtype:
+        Restriction keys should not be present in attr space. Non-key attributes should live in attribute space.
         """
         a = A.create(id=id, name=name, status=status)
         assert not any([our_hasattr(a, e) for e in A._restrictions.keys()])
@@ -369,20 +316,17 @@ class TestDataObject:
         class Second(DataObject):
             _restrictions = {'id': R.INT}
 
-        try:
+        with pytest.raises(DataObjectError):
             type('Mixed', (DataObject,), {'_restrictions': {'id': [First, Second]}, '__module__': 'pytest'})
-            raise MyTestException('Mixed Data Objects should not be allowed in restrictions')
-        except DataObjectError:
-            assert True
 
     @pytest.mark.parametrize('id, name, status', short_data)
     def test_dir(self, id, name, status):
         inst = A.create(id=id, name=name, status=status)
         for k in A._restrictions:
-            assert k in dir(inst)
-        assert 'create' in dir(inst)
+            assert k in dir(inst), 'Restriction key %r missing from dir()' % k
+        assert 'create' in dir(inst), 'classmethod "create" missing from dir()'
 
     def test_schema(self):
         schema = A.schema
         for k in A._restrictions:
-            assert k in schema
+            assert k in schema, 'Key %r missing from schema' % k

--- a/tests/test_managed_restrictions.py
+++ b/tests/test_managed_restrictions.py
@@ -114,10 +114,8 @@ class TestManagedRestrictions:
     @pytest.mark.parametrize('state', ['TX'])
     def test_recovery(self, name, age, city, state, valid_city, invalid_city):
         a = A(data={'name': name, 'age': age, 'city': city, 'state': state})
-        try:
+        with pytest.raises(AssertionError):
             a.city = invalid_city
-        except Exception:
-            pass
 
         def f_attr(kv):
             return getattr(a, kv[0]) == kv[1]
@@ -142,10 +140,8 @@ class TestManagedRestrictions:
     def test_data_corruption_robustness(self, name, age, invalid_city, city, state):
         a = A(data={'name': name, 'age': age, 'city': city, 'state': state})
         assert a.city == city
-        try:
-            a.city = invalid_city
-            assert False
-        except Exception:
-            assert True
 
-        assert a.city == city
+        with pytest.raises(AssertionError):
+            a.city = invalid_city
+
+        assert a.city == city, 'Data was corrupted after failed validation'


### PR DESCRIPTION
## Phase 1: Fix Anti-Patterns in Existing Tests

### Changes
- **Replace all `try/except/assert False` patterns** with `pytest.raises()` across 3 test files:
  - `test_data_object.py` (~10 instances)
  - `test_abc_restrictions.py` (~5 instances)
  - `test_managed_restrictions.py` (~1 instance)
- **Fix ABC test teardown**: Added a pytest fixture with `yield` + cleanup for `ABCRestrictionMeta` global state, replacing the fragile manual teardown (which had a TODO for failure handling)
- **Add assertion messages** to bare `assert` statements for better diagnostics
- **Remove `MyTestException`** — no longer needed now that `pytest.raises` is used

### Why
The old pattern (`except Exception: assert True`) catches *any* exception, meaning tests can pass for the wrong reason. `pytest.raises(SpecificError)` ensures only the expected exception type counts as a pass.

### Test results
Same as before: **172 passed, 76 xfailed** — no behavioral changes.