### PR TITLE
test: close coverage gaps in dynamic restrictions, datetime, managed list, R shortcuts

### DIFF
--- a/tests/test_common/test_managed_datetime.py
+++ b/tests/test_common/test_managed_datetime.py
@@ -77,8 +77,6 @@ class TestMgdDatetime:
         [
             (test_dt_instance_now, test_dt_instance_now),
             (test_dt_instance_now.isoformat(), test_dt_instance_now),
-            # This creates race condition.
-            # pytest.param(None, test_dt_instance_now, marks=pytest.mark.xfail(raises=RestrictionError))
         ],
     )
     def test_to_datetime(self, input, output):
@@ -197,3 +195,86 @@ class TestMgdDatetime:
         """
         instance = MgdDatetime.null_date()
         assert instance(input) == output
+
+
+class TestMgdDatetimeMalformedStrings:
+    """Test that malformed ISO strings raise RestrictionError via the manage() path."""
+
+    @pytest.mark.parametrize(
+        'bad_input',
+        [
+            'not-a-date',
+            '2020-13-45',
+            '2020/01/01',
+            'hello world',
+            '12345',
+            '',
+        ],
+    )
+    def test_malformed_datetime_string(self, bad_input):
+        """Malformed string should raise RestrictionError from strptime ValueError."""
+        instance = MgdDatetime.datetime()
+        with pytest.raises(RestrictionError):
+            instance(bad_input)
+
+    @pytest.mark.parametrize(
+        'bad_input',
+        [
+            'not-a-date',
+            '2020-13-45',
+            '2020/01/01',
+            '',
+        ],
+    )
+    def test_malformed_date_string(self, bad_input):
+        """Malformed date string should raise RestrictionError."""
+        instance = MgdDatetime.date()
+        with pytest.raises(RestrictionError):
+            instance(bad_input)
+
+
+class TestMgdDatetimeDefaultKeyNone:
+    """Test behavior when default_key is None and data is None."""
+
+    def test_datetime_no_default_none_input(self):
+        """With no default_key and non-nullable, None should fail restriction."""
+        instance = MgdDatetime(dt_obj=datetime, default_key=None, nullable=False)
+        with pytest.raises(RestrictionError):
+            instance(None)
+
+    def test_datetime_no_default_nullable_none_input(self):
+        """With no default_key but nullable, None should pass through."""
+        instance = MgdDatetime(dt_obj=datetime, default_key=None, nullable=True)
+        result = instance(None)
+        assert result is None
+
+    def test_date_no_default_nullable_none_input(self):
+        """With no default_key but nullable date, None should pass through."""
+        instance = MgdDatetime(dt_obj=date, default_key=None, nullable=True)
+        result = instance(None)
+        assert result is None
+
+
+class TestMgdDatetimeInvalidInit:
+    """Test that invalid constructor args are rejected."""
+
+    def test_invalid_dt_obj(self):
+        """dt_obj must be date or datetime."""
+        with pytest.raises(AssertionError):
+            MgdDatetime(dt_obj=str)
+
+    def test_invalid_default_key(self):
+        """default_key must be None, 'from', or 'to'."""
+        with pytest.raises(AssertionError):
+            MgdDatetime(dt_obj=datetime, default_key='invalid')
+
+
+class TestMgdDatetimeMicrosecondStripping:
+    """Verify that microseconds are stripped for datetime results."""
+
+    def test_microseconds_stripped(self):
+        """datetime results should have microsecond=0."""
+        dt_with_micro = datetime(2020, 1, 1, 12, 0, 0, 123456)
+        instance = MgdDatetime.datetime()
+        result = instance(dt_with_micro)
+        assert result.microsecond == 0

--- a/tests/test_common/test_managed_list.py
+++ b/tests/test_common/test_managed_list.py
@@ -6,7 +6,8 @@ import pytest
 
 from do_py import DataObject
 from do_py.common import R
-from do_py.common.managed_list import ManagedList
+from do_py.common.managed_list import ManagedList, OrderedManagedList
+from do_py.exceptions import RestrictionError
 
 
 class Book(DataObject):
@@ -44,3 +45,113 @@ class TestManagedList:
     )
     def test_managed_list(self, books, shelves):
         assert Library({'books': books, 'shelves': shelves})
+
+    def test_items_are_do_instances(self):
+        """All items in the managed list should be proper DataObject instances."""
+        lib = Library({'books': [self.book_1, self.book_2], 'shelves': None})
+        for book in lib.books:
+            assert type(book) is Book, 'Expected Book instance, got %s' % type(book)
+
+    def test_mixed_dict_and_do_input(self):
+        """List with a mix of dicts and DO instances should all become DO instances."""
+        lib = Library({'books': [self.book_1, Book(self.book_2)], 'shelves': None})
+        assert len(lib.books) == 2
+        for book in lib.books:
+            assert type(book) is Book
+
+    def test_non_nullable_none_raises(self):
+        """Non-nullable ManagedList with None data should raise RestrictionError."""
+        ml = ManagedList(Book, nullable=False)
+        with pytest.raises(RestrictionError):
+            ml(None)
+
+    def test_nullable_none_ok(self):
+        """Nullable ManagedList with None data should succeed."""
+        ml = ManagedList(Bookshelf, nullable=True)
+        result = ml(None)
+        assert result is None
+
+    def test_schema_value(self):
+        """schema_value should return a list containing the DO's schema."""
+        ml = ManagedList(Book)
+        schema = ml.schema_value
+        assert isinstance(schema, list)
+        assert len(schema) == 1
+        assert schema[0] == Book.schema
+
+
+class SortableItem(DataObject):
+    _restrictions = {'name': R.STR, 'priority': R.INT}
+
+
+class TestOrderedManagedList:
+    """Tests for OrderedManagedList (previously had # TODO: Unit tests)."""
+
+    def test_basic_sorting(self):
+        """Items should be sorted by the key function."""
+
+        class SortedContainer(DataObject):
+            _restrictions = {'entries': OrderedManagedList(SortableItem, key=lambda x: x.priority)}
+
+        data = {
+            'entries': [
+                {'name': 'c', 'priority': 3},
+                {'name': 'a', 'priority': 1},
+                {'name': 'b', 'priority': 2},
+            ]
+        }
+        container = SortedContainer(data)
+        priorities = [item.priority for item in container.entries]
+        assert priorities == [1, 2, 3], 'Expected sorted order, got %s' % priorities
+
+    def test_reverse_sorting(self):
+        """Items should be sorted in reverse when reverse=True."""
+
+        class ReverseSortedContainer(DataObject):
+            _restrictions = {'entries': OrderedManagedList(SortableItem, key=lambda x: x.priority, reverse=True)}
+
+        data = {
+            'entries': [
+                {'name': 'a', 'priority': 1},
+                {'name': 'c', 'priority': 3},
+                {'name': 'b', 'priority': 2},
+            ]
+        }
+        container = ReverseSortedContainer(data)
+        priorities = [item.priority for item in container.entries]
+        assert priorities == [3, 2, 1], 'Expected reverse sorted order, got %s' % priorities
+
+    @pytest.mark.xfail(raises=TypeError, reason='Bug: OrderedManagedList.manage() calls sorted(None)')
+    def test_nullable_ordered_list(self):
+        """Nullable OrderedManagedList should accept None but currently doesn't due to a bug."""
+
+        class NullableContainer(DataObject):
+            _restrictions = {'entries': OrderedManagedList(SortableItem, nullable=True, key=lambda x: x.priority)}
+
+        container = NullableContainer({'entries': None})
+        assert container.entries is None
+
+    def test_non_nullable_ordered_list_none_raises(self):
+        """Non-nullable OrderedManagedList should reject None."""
+        oml = OrderedManagedList(SortableItem, key=lambda x: x.priority)
+        with pytest.raises(RestrictionError):
+            oml(None)
+
+    def test_items_are_do_instances(self):
+        """Items in OrderedManagedList should be DO instances after processing."""
+
+        class SortedContainer(DataObject):
+            _restrictions = {'entries': OrderedManagedList(SortableItem, key=lambda x: x.priority)}
+
+        data = {'entries': [{'name': 'a', 'priority': 1}]}
+        container = SortedContainer(data)
+        assert type(container.entries[0]) is SortableItem
+
+    def test_empty_list(self):
+        """Empty list should be valid and remain empty after sorting."""
+
+        class SortedContainer(DataObject):
+            _restrictions = {'entries': OrderedManagedList(SortableItem, key=lambda x: x.priority)}
+
+        container = SortedContainer({'entries': []})
+        assert container.entries == []

--- a/tests/test_common/test_r.py
+++ b/tests/test_common/test_r.py
@@ -5,6 +5,7 @@
 import pytest
 
 from do_py.common import R
+from do_py.data_object.restriction import AbstractRestriction
 
 
 class TestR:
@@ -22,3 +23,83 @@ class TestR:
     )
     def test_r_creation(self, args, kwargs):
         assert R(*args, **kwargs)
+
+
+class TestRShortcuts:
+    """Verify each R shortcut returns a valid restriction with correct behavior."""
+
+    @pytest.mark.parametrize(
+        'shortcut, valid_value, invalid_value',
+        [
+            ('INT', 42, 'not_int'),
+            ('FLOAT', 3.14, 'not_float'),
+            ('STR', 'hello', 123),
+            ('BOOL', True, 'not_bool'),
+            ('LIST', [1, 2], 'not_list'),
+            ('SET', {1, 2}, 'not_set'),
+        ],
+    )
+    def test_type_shortcut(self, shortcut, valid_value, invalid_value):
+        """Each type shortcut should accept the correct type and reject others."""
+        restriction = getattr(R, shortcut)
+        assert isinstance(restriction, AbstractRestriction), '%s did not return an AbstractRestriction' % shortcut
+        # Valid value should pass
+        result = restriction(valid_value)
+        assert result == valid_value
+        # Invalid value should raise
+        from do_py.exceptions import RestrictionError
+
+        with pytest.raises(RestrictionError):
+            restriction(invalid_value)
+
+    @pytest.mark.parametrize(
+        'shortcut, none_allowed',
+        [
+            ('NULL_INT', True),
+            ('NULL_FLOAT', True),
+            ('NULL_STR', True),
+            ('NULL_LIST', True),
+            ('NULL_DATETIME', True),
+            ('NULL_DATE', True),
+            ('NULL_LONG_INT', True),
+        ],
+    )
+    def test_nullable_shortcut_accepts_none(self, shortcut, none_allowed):
+        """Nullable shortcuts should accept None."""
+        restriction = getattr(R, shortcut)
+        assert isinstance(restriction, AbstractRestriction)
+        result = restriction(None)
+        assert result is None
+
+    @pytest.mark.parametrize(
+        'shortcut',
+        ['INT', 'FLOAT', 'STR', 'BOOL', 'LIST', 'SET'],
+    )
+    def test_non_nullable_rejects_none(self, shortcut):
+        """Non-nullable shortcuts should reject None."""
+        from do_py.exceptions import RestrictionError
+
+        restriction = getattr(R, shortcut)
+        with pytest.raises(RestrictionError):
+            restriction(None)
+
+    def test_bool_int(self):
+        """BOOL_INT should accept 0 and 1 only."""
+        from do_py.exceptions import RestrictionError
+
+        r = R.BOOL_INT
+        assert r(0) == 0
+        assert r(1) == 1
+        with pytest.raises(RestrictionError):
+            r(2)
+
+    def test_long_int(self):
+        """LONG_INT should behave identically to INT in Python 3."""
+        r = R.LONG_INT
+        assert r(42) == 42
+
+    def test_null_long_int(self):
+        """NULL_LONG_INT should accept int and None."""
+        r = R.NULL_LONG_INT
+        assert r(42) == 42
+        assert r(None) is None

--- a/tests/test_data_object/test_dynamic_restrictions.py
+++ b/tests/test_data_object/test_dynamic_restrictions.py
@@ -6,7 +6,8 @@ Test dynamic restriction class creation, inheritance and usage.
 import pytest
 
 from do_py import DataObject, R
-from do_py.data_object.dynamic_restrictions import dynamic_restriction_mixin
+from do_py.data_object.dynamic_restrictions import DynamicRestrictions, dynamic_restriction_mixin
+from do_py.exceptions import DataObjectError, RestrictionError
 
 
 class MilkMetadata(DataObject):
@@ -78,6 +79,80 @@ class TestDynamicDataObject:
         assert breakfast.item_metadata.flavor == 'chocolate'
         breakfast.item_metadata.flavor = 'normal'
         assert breakfast.item_metadata.flavor == 'normal'
+
+
+class TestDynamicSetItem:
+    """Test __setitem__ paths for dynamic restrictions."""
+
+    def test_setitem_dependent_key_valid(self):
+        """Setting the dependent key with matching data should succeed."""
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        breakfast['item_metadata'] = MilkMetadata({'flavor': 'normal'})
+        assert breakfast.item_metadata.flavor == 'normal'
+
+    def test_setitem_dependent_key_mismatched_restriction(self):
+        """Setting the dependent key with mismatched data should fail."""
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        with pytest.raises((DataObjectError, RestrictionError, AssertionError)):
+            breakfast['item_metadata'] = CerealMetadata({'brand': 'cheerios'})
+
+    def test_setitem_non_dynamic_key(self):
+        """Setting a key that is not dynamic should work normally."""
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        breakfast['name'] = 'morning milk'
+        assert breakfast.name == 'morning milk'
+
+    def test_setitem_independent_key_same_type(self):
+        """Changing the independent key while dependent value is still compatible."""
+        # Create two breakfasts to verify setitem on dependent works per-type
+        milk = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        milk.item_metadata = MilkMetadata({'flavor': 'normal'})
+        assert milk._restrictions['item_metadata'] == MilkMetadata
+        assert milk.item_metadata.flavor == 'normal'
+
+
+class TestDynamicInstanceIsolation:
+    """Verify that two instances with different dynamic restrictions don't share state."""
+
+    def test_two_instances_independent(self):
+        """Two instances with different items should have independent restrictions."""
+        milk = Breakfast({'item': 'milk', 'item_metadata': MilkMetadata({'flavor': 'chocolate'})})
+        cereal = Breakfast({'item': 'cereal', 'item_metadata': CerealMetadata({'brand': 'cheerios'})})
+
+        assert milk._restrictions['item_metadata'] == MilkMetadata
+        assert cereal._restrictions['item_metadata'] == CerealMetadata
+
+        # Mutating one should not affect the other
+        milk.item_metadata.flavor = 'normal'
+        assert cereal.item_metadata.brand == 'cheerios'
+
+    def test_class_restrictions_untouched(self):
+        """Class-level restrictions should never be mutated by instance creation."""
+        assert Breakfast._restrictions['item_metadata'] == R()
+        Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        assert Breakfast._restrictions['item_metadata'] == R()
+
+
+class TestDynamicRestrictionsManagedRestriction:
+    """Direct tests for the DynamicRestrictions ManagedRestrictions class."""
+
+    def test_valid_dynamic_restrictions(self):
+        """DynamicRestrictions.manage should succeed with valid DO mappings."""
+        dr = DynamicRestrictions()
+        result = dr({'milk': MilkMetadata, 'cereal': CerealMetadata})
+        assert result == {'milk': MilkMetadata, 'cereal': CerealMetadata}
+
+    def test_empty_dict_fails(self):
+        """DynamicRestrictions.manage should fail with an empty dict."""
+        dr = DynamicRestrictions()
+        with pytest.raises(AssertionError, match='empty'):
+            dr({})
+
+    def test_non_dataobject_value_fails(self):
+        """DynamicRestrictions.manage should fail if a value is not a DataObject."""
+        dr = DynamicRestrictions()
+        with pytest.raises(AssertionError):
+            dr({'bad': int})
 
 
 class TestInheritance:


### PR DESCRIPTION
## Phase 2b: Close Coverage Gaps

Targets the four modules with the lowest coverage after ABC.

### Dynamic Restrictions (58.6% → ~80%)
- **TestDynamicSetItem** — setitem on dependent key (valid/mismatched), non-dynamic key, same-type update
- **TestDynamicInstanceIsolation** — two instances don't share restrictions, class-level untouched
- **TestDynamicRestrictionsManagedRestriction** — direct tests for `DynamicRestrictions.manage()`: valid, empty dict, non-DO value

### MgdDatetime (63.9% → ~90%)
- **TestMgdDatetimeMalformedStrings** — malformed ISO strings trigger `RestrictionError` via `strptime` → `ValueError` conversion
- **TestMgdDatetimeDefaultKeyNone** — `default_key=None` with nullable/non-nullable + `None` input
- **TestMgdDatetimeInvalidInit** — invalid `dt_obj` and `default_key` constructor args
- **TestMgdDatetimeMicrosecondStripping** — verify `microsecond=0` on datetime results

### ManagedList (78.6% → ~95%)
- Item type verification, mixed dict/DO input, nullable/non-nullable direct tests, `schema_value`

### OrderedManagedList (0% → ~90%)
- Full test suite: basic sorting, reverse, empty list, DO instance check
- **Discovered bug**: `OrderedManagedList.manage()` calls `sorted(None)` when nullable — marked as `xfail`

### R Shortcuts (89.9% → ~100%)
- **TestRShortcuts** — each shortcut returns valid `AbstractRestriction` with correct accept/reject behavior, nullable vs non-nullable, `BOOL_INT`, `LONG_INT`, `NULL_LONG_INT`

### Test results
**229 passed, 77 xfailed** (57 new tests)