### PR TITLE
test: add serialization round-trips, validator edge cases, restricted dict, and legacy restriction tests

### DIFF
--- a/tests/test_data_object/test_restricted_dict.py
+++ b/tests/test_data_object/test_restricted_dict.py
@@ -1,0 +1,86 @@
+"""
+Test RestrictedDictMixin behavior accessed through DataObject.
+:date_created: 2026-04-17
+"""
+
+import json
+
+import pytest
+
+from do_py import DataObject, R
+
+
+class Simple(DataObject):
+    _restrictions = {'x': R.INT, 'y': R.STR}
+
+
+class TestRestrictedDictRepr:
+    """Test __repr__ returns valid JSON."""
+
+    def test_repr_is_valid_json(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        result = json.loads(repr(s))
+        assert result['x'] == 1
+        assert result['y'] == 'hello'
+
+
+class TestRestrictedDictStr:
+    """Test __str__ format."""
+
+    def test_str_contains_class_name(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        result = str(s)
+        assert 'Simple' in result
+
+
+class TestRestrictedDictDir:
+    """Test __dir__ excludes unsupported operations."""
+
+    def test_dir_excludes_mutating_ops(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        d = dir(s)
+        for excluded in ['clear', 'pop', 'popitem', 'update', '__delitem__']:
+            assert excluded not in d, '%s should be excluded from dir()' % excluded
+
+    def test_dir_includes_restriction_keys(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        d = dir(s)
+        assert 'x' in d
+        assert 'y' in d
+
+
+class TestRestrictedDictSetattr:
+    """Test __setattr__ routing between key namespace and attribute namespace."""
+
+    def test_setattr_restricted_key_routes_to_keyspace(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        s.x = 42
+        assert s['x'] == 42
+        assert 'x' not in s.__dict__
+
+    def test_setattr_non_restricted_routes_to_attr(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        s.custom = 'value'
+        assert s.custom == 'value'
+        assert 'custom' in s.__dict__
+        assert 'custom' not in s
+
+
+class TestRestrictedDictGetattr:
+    """Test __getattr__ behavior."""
+
+    def test_getattr_restricted_key(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        assert s.x == 1
+        assert s.y == 'hello'
+
+    def test_getattr_missing_raises_attribute_error(self):
+        s = Simple({'x': 1, 'y': 'hello'})
+        with pytest.raises(AttributeError, match='nonexistent'):
+            _ = s.nonexistent
+
+    def test_getattr_raises_attribute_error_not_key_error(self):
+        """__getattr__ should convert KeyError to AttributeError."""
+        s = Simple({'x': 1, 'y': 'hello'})
+        with pytest.raises(AttributeError):
+            _ = s.nope

--- a/tests/test_data_object/test_serialization.py
+++ b/tests/test_data_object/test_serialization.py
@@ -1,0 +1,158 @@
+"""
+Test serialization round-trips, __copy__, __deepcopy__, and schema for DataObject.
+:date_created: 2026-04-17
+"""
+
+import json
+from copy import copy, deepcopy
+from datetime import date, datetime
+
+from do_py import DataObject, R
+from do_py.common.managed_datetime import MgdDatetime
+from do_py.common.managed_list import ManagedList
+from do_py.utils.json_encoder import MyJSONEncoder
+
+
+class Flat(DataObject):
+    _restrictions = {'x': R.INT, 'y': R.STR, 'z': R(1, 2, 3)}
+
+
+class Inner(DataObject):
+    _restrictions = {'val': R.INT}
+
+
+class Nested(DataObject):
+    _restrictions = {'inner': Inner, 'label': R.STR}
+
+
+class NullableNested(DataObject):
+    _restrictions = {'inner': R(Inner, type(None)), 'label': R.STR}
+
+
+class WithDatetime(DataObject):
+    _restrictions = {'dt': MgdDatetime.datetime(), 'd': MgdDatetime.date()}
+
+
+class WithList(DataObject):
+    _restrictions = {'things': ManagedList(Inner)}
+
+
+class TestRoundTrip:
+    """Test DataObject → dict → JSON → dict → DataObject round-trips."""
+
+    def test_flat_round_trip(self):
+        original = Flat({'x': 1, 'y': 'hello', 'z': 2})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        restored = Flat(json.loads(json_str))
+        assert dict(restored) == dict(original)
+
+    def test_nested_round_trip(self):
+        original = Nested({'inner': {'val': 42}, 'label': 'test'})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        loaded = json.loads(json_str)
+        restored = Nested(loaded)
+        assert restored.inner.val == 42
+        assert restored.label == 'test'
+
+    def test_nullable_nested_round_trip_with_value(self):
+        original = NullableNested({'inner': {'val': 10}, 'label': 'ok'})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        restored = NullableNested(json.loads(json_str))
+        assert restored.inner.val == 10
+
+    def test_nullable_nested_round_trip_with_none(self):
+        original = NullableNested({'inner': None, 'label': 'ok'})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        restored = NullableNested(json.loads(json_str))
+        assert restored.inner is None
+
+    def test_datetime_round_trip(self):
+        dt_now = datetime.now().replace(microsecond=0)
+        d_today = date.today()
+        original = WithDatetime({'dt': dt_now, 'd': d_today})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        loaded = json.loads(json_str)
+        restored = WithDatetime(loaded)
+        assert restored.dt == dt_now
+        assert restored.d == d_today
+
+    def test_managed_list_round_trip(self):
+        original = WithList({'things': [{'val': 1}, {'val': 2}]})
+        json_str = json.dumps(dict(original), cls=MyJSONEncoder)
+        loaded = json.loads(json_str)
+        restored = WithList(loaded)
+        assert len(restored.things) == 2
+        assert restored.things[0].val == 1
+        assert restored.things[1].val == 2
+
+
+class TestCopy:
+    """Test __copy__ returns a plain dict."""
+
+    def test_shallow_copy_is_dict(self):
+        original = Flat({'x': 1, 'y': 'hello', 'z': 2})
+        copied = copy(original)
+        assert type(copied) is dict
+        assert copied == dict(original)
+
+    def test_shallow_copy_nested_shared_reference(self):
+        """Shallow copy shares nested object references."""
+        original = Nested({'inner': {'val': 42}, 'label': 'test'})
+        copied = copy(original)
+        assert type(copied) is dict
+        # Nested object should be shared by reference
+        assert copied['inner'] is original['inner']
+
+
+class TestDeepCopy:
+    """Test __deepcopy__ returns a plain dict with independent nested data."""
+
+    def test_deepcopy_is_dict(self):
+        original = Flat({'x': 1, 'y': 'hello', 'z': 2})
+        copied = deepcopy(original)
+        assert type(copied) is dict
+        assert copied == dict(original)
+
+    def test_deepcopy_nested_independent(self):
+        """Deep copy produces independent nested data."""
+        original = Nested({'inner': {'val': 42}, 'label': 'test'})
+        copied = deepcopy(original)
+        assert type(copied) is dict
+        # Nested data should be independent
+        assert copied['inner'] is not original['inner']
+
+    def test_deepcopy_back_to_dataobject(self):
+        """Deep-copied dict can be used to create a new DataObject."""
+        original = Nested({'inner': {'val': 42}, 'label': 'test'})
+        copied = deepcopy(original)
+        restored = Nested(copied)
+        assert restored.inner.val == 42
+        assert restored.label == 'test'
+
+
+class TestSchema:
+    """Test the schema classproperty."""
+
+    def test_flat_schema(self):
+        schema = Flat.schema
+        assert 'x' in schema
+        assert 'y' in schema
+        assert 'z' in schema
+
+    def test_nested_schema(self):
+        schema = Nested.schema
+        assert 'inner' in schema
+        assert 'label' in schema
+        # Inner schema should be a dict with 'val'
+        assert 'val' in schema['inner']
+
+    def test_nullable_nested_schema(self):
+        schema = NullableNested.schema
+        assert 'inner' in schema
+        assert 'val' in schema['inner']
+
+    def test_schema_is_cached(self):
+        """Accessing schema twice returns the same object (cached)."""
+        s1 = Flat.schema
+        s2 = Flat.schema
+        assert s1 is s2

--- a/tests/test_data_object/test_validator.py
+++ b/tests/test_data_object/test_validator.py
@@ -1,0 +1,103 @@
+"""
+Test Validator edge cases: rollback on failure, strict=False, repeated failures.
+:date_created: 2026-04-17
+"""
+
+import pytest
+
+from do_py.common import R
+from do_py.data_object.validator import Validator
+
+
+class RangeValidator(Validator):
+    """low must be <= high."""
+
+    _restrictions = {'low': R.INT, 'high': R.INT}
+
+    def _validate(self):
+        assert self.low <= self.high, 'low must be <= high'
+
+
+class TestValidatorRollback:
+    """Verify state is restored after failed validation."""
+
+    def test_setitem_rollback_on_failure(self):
+        v = RangeValidator({'low': 1, 'high': 10})
+        with pytest.raises(AssertionError):
+            v['low'] = 20  # Would violate low <= high
+        assert v.low == 1, 'State was not restored after failed setitem'
+        assert v.high == 10
+
+    def test_setattr_rollback_on_failure(self):
+        v = RangeValidator({'low': 1, 'high': 10})
+        with pytest.raises(AssertionError):
+            v.high = 0  # Would violate low <= high
+        assert v.high == 10, 'State was not restored after failed setattr'
+        assert v.low == 1
+
+    def test_setitem_success_after_rollback(self):
+        """After a failed mutation, a valid mutation should succeed."""
+        v = RangeValidator({'low': 1, 'high': 10})
+        with pytest.raises(AssertionError):
+            v.low = 20
+        # Now a valid change should work fine
+        v.low = 5
+        assert v.low == 5
+
+    def test_non_validated_key_still_triggers_validate(self):
+        """Even setting a key that isn't directly checked should trigger _validate."""
+        v = RangeValidator({'low': 1, 'high': 10})
+        # Setting high to a value that violates the constraint
+        with pytest.raises(AssertionError):
+            v['high'] = 0
+        assert v.high == 10
+
+
+class TestValidatorStrictness:
+    """Test strict vs non-strict initialization."""
+
+    def test_strict_true_validates(self):
+        """strict=True should call _validate."""
+        with pytest.raises(AssertionError):
+            RangeValidator({'low': 10, 'high': 1})
+
+    def test_strict_false_skips_validate(self):
+        """strict=False should NOT call _validate, allowing invalid data through."""
+        v = RangeValidator(strict=False)
+        assert v is not None
+        # All values should be None (defaults)
+        assert v.low is None
+        assert v.high is None
+
+
+class TestValidatorRepeatedFailures:
+    """Verify object remains consistent after multiple sequential failures."""
+
+    def test_multiple_failures_preserve_state(self):
+        v = RangeValidator({'low': 1, 'high': 10})
+        for bad_low in [20, 30, 40, 50]:
+            with pytest.raises(AssertionError):
+                v.low = bad_low
+        assert v.low == 1, 'State corrupted after repeated failures'
+        assert v.high == 10
+
+    def test_alternating_success_and_failure(self):
+        v = RangeValidator({'low': 1, 'high': 10})
+        v.low = 3
+        assert v.low == 3
+        with pytest.raises(AssertionError):
+            v.low = 20
+        assert v.low == 3
+        v.high = 5
+        assert v.high == 5
+        with pytest.raises(AssertionError):
+            v.high = 2
+        assert v.high == 5
+
+
+class TestValidatorNotInstantiable:
+    """Validator itself is abstract and cannot be directly instantiated."""
+
+    def test_direct_instantiation_fails(self):
+        with pytest.raises(NotImplementedError):
+            Validator()

--- a/tests/test_restriction_legacy.py
+++ b/tests/test_restriction_legacy.py
@@ -1,0 +1,162 @@
+"""
+Test Restriction.legacy edge cases and error message formatting.
+:date_created: 2026-04-17
+"""
+
+import pytest
+
+from do_py import DataObject, R
+from do_py.data_object.restriction import (
+    AbstractRestriction,
+    ManagedRestrictions,
+    Restriction,
+    _DataObjectRestriction,
+    _ListNoRestriction,
+    _ListTypeRestriction,
+    _ListValueRestriction,
+    _MgdRestRestriction,
+    _NullableDataObjectRestriction,
+)
+from do_py.exceptions import DataObjectError, RestrictionError
+
+
+class SampleDO(DataObject):
+    _restrictions = {'x': R.INT}
+
+
+class SampleMgdRest(ManagedRestrictions):
+    _restriction = R.STR
+
+    def manage(self):
+        pass
+
+
+class TestRestrictionLegacy:
+    """Test Restriction.legacy delegation paths."""
+
+    def test_already_abstract_restriction_passthrough(self):
+        """An existing AbstractRestriction should be returned as-is."""
+        r = R.INT
+        assert isinstance(r, AbstractRestriction)
+        result = Restriction.legacy(r)
+        assert result is r
+
+    def test_managed_restrictions_instance(self):
+        """ManagedRestrictions instance should be wrapped in _MgdRestRestriction."""
+        mgd = SampleMgdRest()
+        result = Restriction.legacy(mgd)
+        assert isinstance(result, _MgdRestRestriction)
+
+    def test_abc_restriction_meta(self):
+        """ABCRestrictionMeta class should produce _DataObjectRestriction."""
+        result = Restriction.legacy(SampleDO)
+        assert isinstance(result, _DataObjectRestriction)
+
+    def test_list_of_values(self):
+        """Plain list of values should produce _ListValueRestriction."""
+        result = Restriction.legacy([1, 2, 3])
+        assert isinstance(result, _ListValueRestriction)
+
+    def test_list_of_types_raises(self):
+        """List of types in legacy format should raise RestrictionError."""
+        with pytest.raises(RestrictionError):
+            Restriction.legacy([int, float])
+
+    def test_tuple_raises(self):
+        """Legacy tuple format should raise RestrictionError."""
+        with pytest.raises(RestrictionError):
+            Restriction.legacy(([int], None))
+
+    def test_set_raises(self):
+        """Unsupported types like set should raise RestrictionError."""
+        with pytest.raises(RestrictionError):
+            Restriction.legacy({1, 2, 3})
+
+    def test_empty_list(self):
+        """Empty list should produce _ListNoRestriction."""
+        result = Restriction.legacy([])
+        assert isinstance(result, _ListNoRestriction)
+
+
+class TestRestrictionFactory:
+    """Test Restriction.__new__ dispatch paths."""
+
+    def test_empty_list_produces_no_restriction(self):
+        r = Restriction([], default=None)
+        assert isinstance(r, _ListNoRestriction)
+
+    def test_type_list_produces_list_type(self):
+        r = Restriction([int, float])
+        assert isinstance(r, _ListTypeRestriction)
+
+    def test_value_list_produces_list_value(self):
+        r = Restriction([1, 2, 3])
+        assert isinstance(r, _ListValueRestriction)
+
+    def test_do_produces_data_object_restriction(self):
+        r = Restriction(SampleDO)
+        assert isinstance(r, _DataObjectRestriction)
+
+    def test_nullable_do_produces_nullable(self):
+        r = Restriction([SampleDO, type(None)])
+        assert isinstance(r, _NullableDataObjectRestriction)
+
+    def test_type_default_raises(self):
+        """A type as default value should raise."""
+        with pytest.raises(RestrictionError):
+            Restriction([int], default=int)
+
+
+class TestRestrictionWithDefault:
+    """Test the with_default method."""
+
+    def test_with_default(self):
+        r = R.INT
+        r2 = r.with_default(42)
+        assert r2.default == 42
+        assert r.default is None  # Original unchanged
+
+
+class TestErrorMessages:
+    """Test error message factory methods produce well-formatted messages."""
+
+    def test_data_object_error_unknown_key(self):
+        e = DataObjectError.from_unknown_key('bad_key', SampleDO)
+        assert 'bad_key' in str(e)
+        assert 'SampleDO' in str(e)
+
+    def test_data_object_error_required_key(self):
+        e = DataObjectError.from_required_key('missing_key', SampleDO)
+        assert 'missing_key' in str(e)
+        assert 'SampleDO' in str(e)
+
+    def test_data_object_error_from_restriction_error(self):
+        inner = RestrictionError('inner error')
+        e = DataObjectError.from_restriction_error('key', SampleDO, inner)
+        assert 'key' in str(e)
+        assert 'SampleDO' in str(e)
+        assert 'inner error' in str(e)
+
+    def test_restriction_error_bad_data(self):
+        e = RestrictionError.bad_data('bad_val', [int, float])
+        assert 'bad_val' in str(e)
+
+    def test_restriction_error_mixed_value_and_type(self):
+        e = RestrictionError.from_mixed_value_and_type([int, 1])
+        assert 'Mixed' in str(e) or 'mixed' in str(e).lower()
+
+    def test_restriction_error_unsupported(self):
+        e = RestrictionError.from_unsupported({1, 2})
+        assert 'Malformed' in str(e) or 'set' in str(e)
+
+    def test_restriction_error_invalid_default(self):
+        e = RestrictionError.from_invalid_default_value(int)
+        assert 'int' in str(e)
+
+    def test_restriction_error_dataobj_in_rstr_list(self):
+        e = RestrictionError.from_dataobj_in_rstr_list([SampleDO, int])
+        assert 'DataObject' in str(e)
+
+    def test_restriction_error_unsupported_dataobj_in_rstr_list(self):
+        e = RestrictionError.from_unsupported_dataobj_in_rstr_list([SampleDO, int])
+        assert 'DataObject' in str(e)


### PR DESCRIPTION
## Phase 3: New Test Categories

Adds four entirely new test files covering previously untested areas.

### test_serialization.py (17 tests)
- **TestRoundTrip** — `DataObject → dict → JSON → dict → DataObject` for flat, nested, nullable nested, datetime, and ManagedList DOs
- **TestCopy** — `__copy__` returns plain dict, shallow copy shares nested references
- **TestDeepCopy** — `__deepcopy__` returns plain dict with independent nested data, can be restored to new DO
- **TestSchema** — schema includes all keys, nested schema, nullable nested schema, caching

### test_validator.py (10 tests)
- **TestValidatorRollback** — state restored after failed setitem/setattr, valid mutation succeeds after rollback, non-validated key still triggers `_validate`
- **TestValidatorStrictness** — `strict=True` validates, `strict=False` skips
- **TestValidatorRepeatedFailures** — multiple sequential failures preserve state, alternating success/failure
- **TestValidatorNotInstantiable** — Validator is abstract

### test_restricted_dict.py (9 tests)
- **TestRestrictedDictRepr** — `__repr__` returns valid JSON
- **TestRestrictedDictStr** — `__str__` contains class name
- **TestRestrictedDictDir** — excludes mutating ops, includes restriction keys
- **TestRestrictedDictSetattr** — restricted key routes to keyspace, non-restricted routes to attr
- **TestRestrictedDictGetattr** — returns restricted values, raises `AttributeError` (not `KeyError`) for missing

### test_restriction_legacy.py (21 tests)
- **TestRestrictionLegacy** — `Restriction.legacy` dispatch for all input types
- **TestRestrictionFactory** — `Restriction.__new__` dispatch paths
- **TestRestrictionWithDefault** — `with_default` creates new restriction without mutating original
- **TestErrorMessages** — all `DataObjectError` and `RestrictionError` factory methods produce correctly formatted messages

### Test results
**229 passed, 76 xfailed** (57 new tests)