### PR TITLE
fix: address PR #66 review findings

### DIFF
--- a/do_py/common/managed_list.py
+++ b/do_py/common/managed_list.py
@@ -61,4 +61,5 @@ class OrderedManagedList(ManagedList):
         Sort the data list after ManagedList does its work.
         """
         super(OrderedManagedList, self).manage()
-        self.data = sorted(self.data, key=self.key, reverse=self.reverse)
+        if self.data is not None:
+            self.data = sorted(self.data, key=self.key, reverse=self.reverse)

--- a/tests/test_common/test_managed_datetime.py
+++ b/tests/test_common/test_managed_datetime.py
@@ -278,3 +278,43 @@ class TestMgdDatetimeMicrosecondStripping:
         instance = MgdDatetime.datetime()
         result = instance(dt_with_micro)
         assert result.microsecond == 0
+
+
+class TestMgdDatetimeCrossTypeInputs:
+    """Test edge cases: passing wrong type (date to datetime(), datetime to date())."""
+
+    def test_date_instance_to_datetime_restriction_fails(self):
+        """Passing a date object to a datetime restriction should fail."""
+        instance = MgdDatetime.datetime()
+        with pytest.raises(RestrictionError):
+            instance(test_date_instance_now)
+
+    def test_datetime_instance_to_date_restriction_fails(self):
+        """Passing a datetime object to a date restriction should fail."""
+        instance = MgdDatetime.date()
+        with pytest.raises(RestrictionError):
+            instance(test_dt_instance_now)
+
+    def test_date_isoformat_to_datetime_restriction_fails(self):
+        """A date-format ISO string should fail when datetime is expected (too short)."""
+        instance = MgdDatetime.datetime()
+        with pytest.raises(RestrictionError):
+            instance(test_date_instance_now.isoformat())
+
+    def test_datetime_isoformat_to_date_restriction_fails(self):
+        """A datetime-format ISO string should fail when date is expected (too long)."""
+        instance = MgdDatetime.date()
+        with pytest.raises(RestrictionError):
+            instance(test_dt_instance_now.isoformat())
+
+    def test_from_from_date_with_datetime_string(self):
+        """from_from_date should reject a datetime-format ISO string."""
+        instance = MgdDatetime.from_from_date()
+        with pytest.raises(RestrictionError):
+            instance(test_dt_instance_now.isoformat())
+
+    def test_from_from_datetime_with_date_string(self):
+        """from_from_datetime should reject a date-format ISO string."""
+        instance = MgdDatetime.from_from_datetime()
+        with pytest.raises(RestrictionError):
+            instance(test_date_instance_now.isoformat())

--- a/tests/test_common/test_managed_list.py
+++ b/tests/test_common/test_managed_list.py
@@ -155,11 +155,14 @@ class TestOrderedManagedList:
         container = SortedContainer({'entries': []})
         assert container.entries == []
 
-    def test_non_list_input_raises(self):
-        """Non-list input (e.g. string, int) should not be silently accepted."""
+    def test_non_list_string_input_raises(self):
+        """String input should be rejected (hits .keys() on non-dict during DO init)."""
         ml = ManagedList(SortableItem)
-        with pytest.raises(Exception):
+        with pytest.raises(AttributeError):
             ml('not a list')
 
-        with pytest.raises(Exception):
+    def test_non_list_int_input_raises(self):
+        """Int input should be rejected (not iterable)."""
+        ml = ManagedList(SortableItem)
+        with pytest.raises(TypeError):
             ml(42)

--- a/tests/test_common/test_managed_list.py
+++ b/tests/test_common/test_managed_list.py
@@ -121,9 +121,8 @@ class TestOrderedManagedList:
         priorities = [item.priority for item in container.entries]
         assert priorities == [3, 2, 1], 'Expected reverse sorted order, got %s' % priorities
 
-    @pytest.mark.xfail(raises=TypeError, reason='Bug: OrderedManagedList.manage() calls sorted(None)')
     def test_nullable_ordered_list(self):
-        """Nullable OrderedManagedList should accept None but currently doesn't due to a bug."""
+        """Nullable OrderedManagedList should accept None."""
 
         class NullableContainer(DataObject):
             _restrictions = {'entries': OrderedManagedList(SortableItem, nullable=True, key=lambda x: x.priority)}
@@ -155,3 +154,12 @@ class TestOrderedManagedList:
 
         container = SortedContainer({'entries': []})
         assert container.entries == []
+
+    def test_non_list_input_raises(self):
+        """Non-list input (e.g. string, int) should not be silently accepted."""
+        ml = ManagedList(SortableItem)
+        with pytest.raises(Exception):
+            ml('not a list')
+
+        with pytest.raises(Exception):
+            ml(42)

--- a/tests/test_common/test_r.py
+++ b/tests/test_common/test_r.py
@@ -6,6 +6,7 @@ import pytest
 
 from do_py.common import R
 from do_py.data_object.restriction import AbstractRestriction
+from do_py.exceptions import RestrictionError
 
 
 class TestR:
@@ -47,8 +48,6 @@ class TestRShortcuts:
         result = restriction(valid_value)
         assert result == valid_value
         # Invalid value should raise
-        from do_py.exceptions import RestrictionError
-
         with pytest.raises(RestrictionError):
             restriction(invalid_value)
 
@@ -77,16 +76,12 @@ class TestRShortcuts:
     )
     def test_non_nullable_rejects_none(self, shortcut):
         """Non-nullable shortcuts should reject None."""
-        from do_py.exceptions import RestrictionError
-
         restriction = getattr(R, shortcut)
         with pytest.raises(RestrictionError):
             restriction(None)
 
     def test_bool_int(self):
         """BOOL_INT should accept 0 and 1 only."""
-        from do_py.exceptions import RestrictionError
-
         r = R.BOOL_INT
         assert r(0) == 0
         assert r(1) == 1

--- a/tests/test_data_object/test_dynamic_restrictions.py
+++ b/tests/test_data_object/test_dynamic_restrictions.py
@@ -7,7 +7,7 @@ import pytest
 
 from do_py import DataObject, R
 from do_py.data_object.dynamic_restrictions import DynamicRestrictions, dynamic_restriction_mixin
-from do_py.exceptions import DataObjectError, RestrictionError
+from do_py.exceptions import DataObjectError
 
 
 class MilkMetadata(DataObject):
@@ -91,9 +91,9 @@ class TestDynamicSetItem:
         assert breakfast.item_metadata.flavor == 'normal'
 
     def test_setitem_dependent_key_mismatched_restriction(self):
-        """Setting the dependent key with mismatched data should fail."""
+        """Setting the dependent key with mismatched data should fail with DataObjectError."""
         breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
-        with pytest.raises((DataObjectError, RestrictionError, AssertionError)):
+        with pytest.raises(DataObjectError):
             breakfast['item_metadata'] = CerealMetadata({'brand': 'cheerios'})
 
     def test_setitem_non_dynamic_key(self):
@@ -102,13 +102,25 @@ class TestDynamicSetItem:
         breakfast['name'] = 'morning milk'
         assert breakfast.name == 'morning milk'
 
-    def test_setitem_independent_key_same_type(self):
-        """Changing the independent key while dependent value is still compatible."""
-        # Create two breakfasts to verify setitem on dependent works per-type
+    def test_setitem_dependent_key_update(self):
+        """Setting the dependent key with a new valid value of the same type should succeed."""
         milk = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
         milk.item_metadata = MilkMetadata({'flavor': 'normal'})
         assert milk._restrictions['item_metadata'] == MilkMetadata
         assert milk.item_metadata.flavor == 'normal'
+
+    def test_setitem_independent_key_revalidates_dependent(self):
+        """Changing the independent key triggers revalidation of the dependent value.
+
+        Since the existing dependent value (MilkMetadata) doesn't match the new restriction
+        (CerealMetadata), this correctly raises an error. The independent and dependent keys
+        are coupled — you cannot change one without the other being compatible.
+        """
+        breakfast = Breakfast({'item': 'milk', 'item_metadata': {'flavor': 'chocolate'}})
+        assert breakfast._restrictions['item_metadata'] == MilkMetadata
+        # Changing independent key revalidates the existing dependent value against the new restriction
+        with pytest.raises(DataObjectError):
+            breakfast['item'] = 'cereal'
 
 
 class TestDynamicInstanceIsolation:


### PR DESCRIPTION
## Addresses review issues from PR #66

### Bug fix
- **OrderedManagedList nullable bug**: Added `None` guard before `sorted()` call in `manage()` — removes the `xfail` marker from the test (now passes)

### Test improvements
- **Pinned exact exception**: `test_setitem_dependent_key_mismatched_restriction` now asserts `DataObjectError` instead of a broad 3-exception tuple
- **Renamed misleading test**: `test_setitem_independent_key_same_type` → `test_setitem_dependent_key_update` (it was testing the dependent key, not the independent)
- **New test for independent key setitem**: `test_setitem_independent_key_revalidates_dependent` covers the coupled revalidation behavior
- **Moved inline imports to top-level** in `test_r.py` (3 occurrences of `from do_py.exceptions import RestrictionError`)
- **Added `test_non_list_input_raises`**: Verifies ManagedList rejects non-list input (string, int)
- **Added `TestMgdDatetimeCrossTypeInputs`**: 6 new tests for cross-type edge cases (date↔datetime) on factory methods

### Test results
**262 passed, 76 xfailed** (1 fewer xfail due to bug fix, net +8 new tests)