### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up uv and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up uv and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -36,4 +36,4 @@ jobs:
             --junitxml test-reports/tests.xml \
             ./tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,4 +36,4 @@ jobs:
             --junitxml test-reports/tests.xml \
             ./tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       id-token: write
     steps:
       - name: Check out the tagged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: '3.12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ on:
   release:
     types: [published]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish:
     name: Build and publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       id-token: write
     steps:
       - name: Check out the tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: '3.12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     name: Build and publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check out the tagged commit
         uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: '3.12'


### PR DESCRIPTION
Silences Node.js 20 deprecation warnings on CI.

- `actions/checkout` v4 → v6
- `astral-sh/setup-uv` v5 → v8.1.0
- `codecov/codecov-action` v4 → v6

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/